### PR TITLE
Перенос названия локального модуля загрузчика из main в renderer через window.api

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,7 +8,12 @@ import {
   handleBinFileOpen,
 } from './file-handlers';
 import { join } from 'path';
-import { FLASHER_LOCAL_PORT, ModuleManager, ModuleStatus } from './modules/ModuleManager';
+import {
+  FLASHER_LOCAL_PORT,
+  LAPKI_FLASHER,
+  ModuleManager,
+  ModuleStatus,
+} from './modules/ModuleManager';
 
 import icon from '../../resources/icon.png?asset';
 import settings from 'electron-settings';
@@ -130,7 +135,7 @@ app.whenReady().then(() => {
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window);
   });
-  ModuleManager.startLocalModule('lapki-flasher');
+  ModuleManager.startLocalModule(LAPKI_FLASHER);
   createWindow();
 
   app.on('activate', function () {
@@ -144,7 +149,7 @@ app.whenReady().then(() => {
 // Кроме macOS, там выход явный, через Cmd+Q.
 app.on('window-all-closed', () => {
   // явно останавливаем загрузчик, так как в некоторых случаях он остаётся висеть
-  ModuleManager.stopModule('lapki-flasher');
+  ModuleManager.stopModule(LAPKI_FLASHER);
   if (process.platform !== 'darwin') {
     app.quit();
   }

--- a/src/main/modules/ModuleManager.ts
+++ b/src/main/modules/ModuleManager.ts
@@ -3,6 +3,8 @@ import { findFreePort } from './freePortFinder';
 import path from 'path';
 export var FLASHER_LOCAL_HOST = 'localhost';
 export var FLASHER_LOCAL_PORT;
+// название локального загрузчика
+export const LAPKI_FLASHER = 'lapki-flasher';
 
 export class ModuleStatus {
   /* 

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -5,7 +5,7 @@ declare global {
     electron: ElectronAPI;
     api: {
       FLASHER_LOCAL_HOST: string;
-      FLASHER_LOCAL_PORT: number;
+      LAPKI_FLASHER: string;
     };
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,11 +1,11 @@
 import { electronAPI } from '@electron-toolkit/preload';
 import { contextBridge } from 'electron';
-import { FLASHER_LOCAL_HOST, FLASHER_LOCAL_PORT } from '../main/modules/ModuleManager';
+import { FLASHER_LOCAL_HOST, LAPKI_FLASHER } from '../main/modules/ModuleManager';
 
 // Custom APIs for renderer
 const api = {
-  FLASHER_LOCAL_PORT,
   FLASHER_LOCAL_HOST,
+  LAPKI_FLASHER,
 };
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/src/renderer/src/components/Loader.tsx
+++ b/src/renderer/src/components/Loader.tsx
@@ -16,6 +16,8 @@ import { EditorManager } from '@renderer/lib/data/EditorManager';
 import { FlasherSelectModal } from './FlasherSelectModal';
 import { ErrorModal, ErrorModalData } from './ErrorModal';
 
+const LAPKI_FLASHER = window.api.LAPKI_FLASHER;
+
 export interface FlasherProps {
   manager: EditorManager | null;
   compilerData: CompilerResult | undefined;
@@ -68,7 +70,7 @@ export const Loader: React.FC<FlasherProps> = ({ manager, compilerData }) => {
   const handleLocalFlasher = async () => {
     console.log('local');
     setFlasherIslocal(true);
-    await manager?.startLocalModule('lapki-flasher');
+    await manager?.startLocalModule(LAPKI_FLASHER);
     //Стандартный порт
     manager?.changeFlasherLocal();
   };
@@ -95,7 +97,7 @@ export const Loader: React.FC<FlasherProps> = ({ manager, compilerData }) => {
     var errorMsg: JSX.Element = <p>`Неизвестный тип ошибки`</p>;
     if (flasherIsLocal) {
       await window.electron.ipcRenderer
-        .invoke('Module:getStatus', 'lapki-flasher')
+        .invoke('Module:getStatus', LAPKI_FLASHER)
         .then(function (obj) {
           let errorDetails = obj.details;
           switch (obj.code) {


### PR DESCRIPTION
Чтобы не обращаться к локльному модулю через литералы.