### PR TITLE
fit icons to containers

### DIFF
--- a/src/renderer/src/components/ComponentAddModal.tsx
+++ b/src/renderer/src/components/ComponentAddModal.tsx
@@ -111,7 +111,7 @@ export const ComponentAddModal: React.FC<ComponentAddModalProps> = ({
               onClick={() => onCompClick(entry)}
             >
               <img
-                style={{ height: '32px' }}
+                className="h-8 w-8 object-contain"
                 src={icons.get(entry.img ?? 'unknown')?.src ?? UnknownIcon}
               />
               <p className="line-clamp-1">{entry.name}</p>

--- a/src/renderer/src/components/Explorer.tsx
+++ b/src/renderer/src/components/Explorer.tsx
@@ -78,7 +78,7 @@ export const Explorer: React.FC<ExplorerProps> = ({ editor, manager }) => {
               onContextMenu={() => onCompRightClick(key)}
             >
               <img
-                className="h-8 w-8"
+                className="w-8 object-cover"
                 src={
                   editor?.container.machine.platform?.getComponentIconUrl(key, true) ?? UnknownIcon
                 }

--- a/src/renderer/src/components/Explorer.tsx
+++ b/src/renderer/src/components/Explorer.tsx
@@ -78,7 +78,7 @@ export const Explorer: React.FC<ExplorerProps> = ({ editor, manager }) => {
               onContextMenu={() => onCompRightClick(key)}
             >
               <img
-                className="w-8 object-cover"
+                className="h-8 w-8 object-contain"
                 src={
                   editor?.container.machine.platform?.getComponentIconUrl(key, true) ?? UnknownIcon
                 }

--- a/src/renderer/src/lib/drawable/Picto.ts
+++ b/src/renderer/src/lib/drawable/Picto.ts
@@ -3,7 +3,7 @@ import UnknownIcon from '@renderer/assets/icons/unknown-alt.svg';
 import EdgeHandle from '@renderer/assets/icons/new transition.svg';
 import { Rectangle } from '@renderer/types/graphics';
 
-import { preloadImagesMap } from '../utils';
+import { drawImageFit, preloadImagesMap } from '../utils';
 
 let imagesLoaded = false;
 
@@ -84,15 +84,15 @@ export class Picto {
 
   drawImage(ctx: CanvasRenderingContext2D, iconName: string, bounds: Rectangle) {
     // console.log([iconName, icons.has(iconName)]);
-    if (!icons.has(iconName)) return;
+    const image = icons.get(iconName);
+    if (!image) return;
+
     ctx.beginPath();
-    ctx.drawImage(
-      icons.get(iconName)!,
-      bounds.x,
-      bounds.y,
-      bounds.width / this.scale,
-      bounds.height / this.scale
-    );
+    drawImageFit(ctx, image, {
+      ...bounds,
+      width: bounds.width / this.scale,
+      height: bounds.height / this.scale,
+    });
     ctx.closePath();
   }
 

--- a/src/renderer/src/lib/utils.ts
+++ b/src/renderer/src/lib/utils.ts
@@ -278,3 +278,25 @@ export const preloadImagesMap = (
 
   return Promise.all(promises);
 };
+
+export const drawImageFit = (
+  ctx: CanvasRenderingContext2D,
+  img: HTMLImageElement,
+  containerBounds: Rectangle
+) => {
+  const { x, y, width, height } = containerBounds;
+
+  const hRatio = width / img.naturalWidth;
+  const vRatio = height / img.naturalHeight;
+  const ratio = Math.min(hRatio, vRatio);
+  const centerShiftX = x + (width - img.naturalWidth * ratio) / 2;
+  const centerShiftY = y + (height - img.naturalHeight * ratio) / 2;
+
+  ctx.drawImage(
+    img,
+    centerShiftX,
+    centerShiftY,
+    img.naturalWidth * ratio,
+    img.naturalHeight * ratio
+  );
+};


### PR DESCRIPTION
### Правильное соотношение сторон иконок. 

В css сделано с помощью object-fit свойства а на канвасе своя функция которая делает тоже самое.