### PR TITLE
fix

### DIFF
--- a/src/renderer/src/lib/data/StateMachine.ts
+++ b/src/renderer/src/lib/data/StateMachine.ts
@@ -247,8 +247,10 @@ export class StateMachine extends EventEmitter {
 
     if (!parent || !child) return;
 
+    let numberOfConnectedActions = 0;
     if (child.data.parent) {
       this.unlinkState(childId, canUndo);
+      numberOfConnectedActions += 1;
     }
 
     // Вычисляем новую координату внутри контейнера
@@ -268,6 +270,7 @@ export class StateMachine extends EventEmitter {
       this.undoRedo.do({
         type: 'linkState',
         args: { parentId, childId },
+        numberOfConnectedActions,
       });
       if (addOnceOff) {
         child.addOnceOff('dragend'); // Линковка состояния меняет его позицию и это плохо для undo


### PR DESCRIPTION
Фикс того чтобы на CTRL+Z состояние выпрыгивало на уровень на котором оно было до этого а не на самый верхний. Сейчас это нельзя проверить потому что нет механики линковки нод внутри другой ноды (при долгом нажатии состояние просто выпрыгивает на верх а не линкуется). **Но** такая механика появится в #49 