### PR TITLE
typed mouse event emitter

### DIFF
--- a/src/renderer/src/lib/basic/Container.ts
+++ b/src/renderer/src/lib/basic/Container.ts
@@ -105,7 +105,7 @@ export class Container extends EventEmitter<ContainerEvents> {
     this.app.mouse.on('mousemove', this.handleMouseMove);
     this.app.mouse.on('contextmenu', this.handleFieldContextMenu);
     this.app.mouse.on('dblclick', this.handleMouseDoubleClick);
-    this.app.mouse.on('wheel', this.handleMouseWheel as any);
+    this.app.mouse.on('wheel', this.handleMouseWheel);
   }
 
   setScale(value: number) {

--- a/src/renderer/src/lib/basic/Mouse.ts
+++ b/src/renderer/src/lib/basic/Mouse.ts
@@ -1,4 +1,5 @@
 import { Point } from '@renderer/types/graphics';
+
 import { MouseEventEmitter, Button } from '../common/MouseEventEmitter';
 
 /**

--- a/src/renderer/src/lib/common/BaseEventEmitter.ts
+++ b/src/renderer/src/lib/common/BaseEventEmitter.ts
@@ -1,0 +1,48 @@
+type EventHandler<T extends object, N extends keyof T> = (e: T[N]) => void;
+
+/**
+ * Система обработки событий с подпиской и генерацией сигналов
+ */
+export abstract class BaseEventEmitter<
+  T extends object,
+  Name extends keyof T = keyof T,
+  Handler extends EventHandler<T, Name> = EventHandler<T, Name>
+> {
+  handlers = new Map<Name, Set<EventHandler<T, Name>>>();
+  offedOnce = new Set<Name>();
+
+  on<N extends Name>(name: N, handler: EventHandler<T, N>) {
+    if (!this.handlers.has(name)) {
+      this.handlers.set(name, new Set());
+    }
+
+    this.handlers.get(name)?.add(handler as Handler); // ? Не знаю что он тут ругается
+  }
+
+  off<N extends Name>(name: N, handler: EventHandler<T, N>) {
+    if (!this.handlers.has(name)) {
+      return;
+    }
+
+    const handlers = this.handlers.get(name);
+    handlers?.delete(handler as Handler); // ? Не знаю что он тут ругается
+
+    if (handlers?.size === 0) {
+      this.handlers.delete(name);
+    }
+  }
+
+  // Странная штука, нужна чтобы на один раз отключить событие
+  addOnceOff(name: Name) {
+    this.offedOnce.add(name);
+  }
+  removeOnceOff(name: Name) {
+    this.offedOnce.delete(name);
+  }
+
+  reset() {
+    this.handlers.clear();
+  }
+
+  abstract emit<N extends Name>(name: N, event: T[N]): void;
+}

--- a/src/renderer/src/lib/common/EventEmitter.ts
+++ b/src/renderer/src/lib/common/EventEmitter.ts
@@ -1,49 +1,12 @@
-type EventHandler<T extends object, N extends keyof T> = (e: T[N]) => void;
+import { BaseEventEmitter } from './BaseEventEmitter';
 
 /**
  * Система обработки событий с подпиской и генерацией сигналов
  */
 export class EventEmitter<
   T extends object,
-  Name extends keyof T = keyof T,
-  Handler extends EventHandler<T, Name> = EventHandler<T, Name>
-> {
-  handlers = new Map<Name, Set<EventHandler<T, Name>>>();
-  offedOnce = new Set<Name>();
-
-  on<N extends Name>(name: N, handler: EventHandler<T, N>) {
-    if (!this.handlers.has(name)) {
-      this.handlers.set(name, new Set());
-    }
-
-    this.handlers.get(name)?.add(handler as Handler); // ? Не знаю что он тут ругается
-  }
-
-  off<N extends Name>(name: N, handler: EventHandler<T, N>) {
-    if (!this.handlers.has(name)) {
-      return;
-    }
-
-    const handlers = this.handlers.get(name);
-    handlers?.delete(handler as Handler); // ? Не знаю что он тут ругается
-
-    if (handlers?.size === 0) {
-      this.handlers.delete(name);
-    }
-  }
-
-  // Странная штука, нужна чтобы на один раз отключить событие
-  addOnceOff(name: Name) {
-    this.offedOnce.add(name);
-  }
-  removeOnceOff(name: Name) {
-    this.offedOnce.delete(name);
-  }
-
-  reset() {
-    this.handlers.clear();
-  }
-
+  Name extends keyof T = keyof T
+> extends BaseEventEmitter<T, Name> {
   emit<N extends Name>(name: N, event: T[N]) {
     if (this.offedOnce.has(name)) {
       this.offedOnce.delete(name);

--- a/src/renderer/src/lib/common/MouseEventEmitter.ts
+++ b/src/renderer/src/lib/common/MouseEventEmitter.ts
@@ -33,7 +33,7 @@ interface MouseEvents {
   mousemove: MyMouseEvent;
   contextmenu: MyMouseEvent;
   dblclick: MyMouseEvent;
-  wheel: MyMouseEvent;
+  wheel: MyMouseEvent & { nativeEvent: WheelEvent };
 }
 
 /**


### PR DESCRIPTION
Просто типизация для MouseEventEmitter. Для этого вынес базовый класс BaseEventEmitter, в котором можно переопределять метод emit