### PR TITLE
Редактирование действий через список в меню события

### DIFF
--- a/src/renderer/src/components/CreateModal.tsx
+++ b/src/renderer/src/components/CreateModal.tsx
@@ -21,12 +21,12 @@ import { Transition } from '@renderer/lib/drawable/Transition';
 import {
   Action,
   Condition as ConditionData,
+  Event,
   Event as StateEvent,
   Variable as VariableData,
 } from '@renderer/types/diagram';
 import { ArgumentProto } from '@renderer/types/platform';
-
-import { defaultTransColor } from './DiagramEditor';
+import { defaultTransColor } from '@renderer/utils';
 
 const operandOptions = [
   {
@@ -81,7 +81,7 @@ interface CreateModalProps {
   isTransition: { target: Transition } | undefined;
   isCondition: Action[] | undefined;
   setIsCondition: React.Dispatch<React.SetStateAction<Action[]>>;
-  onOpenEventsModal: () => void;
+  onOpenEventsModal: (event?: Event) => void;
   onClose: () => void;
   onSubmit: (data: CreateModalResult) => void;
 }
@@ -780,6 +780,7 @@ export const CreateModal: React.FC<CreateModalProps> = ({
                 onDragOver={(event) => event.preventDefault()}
                 onDragStart={() => handleDrag(key)}
                 onDrop={() => handleDrop(key)}
+                onDoubleClick={() => onOpenEventsModal(data)}
               >
                 <div
                   className={twMerge(
@@ -804,7 +805,7 @@ export const CreateModal: React.FC<CreateModalProps> = ({
           {method.length === 0 && <div className="mx-2 my-2 flex">(нет действий)</div>}
         </div>
         <div className="flex flex-col gap-2">
-          <button type="button" className="btn-secondary p-1" onClick={onOpenEventsModal}>
+          <button type="button" className="btn-secondary p-1" onClick={() => onOpenEventsModal()}>
             <AddIcon />
           </button>
           <button type="button" className="btn-secondary p-1" onClick={deleteMethod}>

--- a/src/renderer/src/components/DiagramEditor.tsx
+++ b/src/renderer/src/components/DiagramEditor.tsx
@@ -5,17 +5,16 @@ import { useDiagramStateName } from '@renderer/hooks/useDiagramStateName';
 import { useModal } from '@renderer/hooks/useModal';
 import { CanvasEditor } from '@renderer/lib/CanvasEditor';
 import { EditorManager } from '@renderer/lib/data/EditorManager';
+import { EventSelection } from '@renderer/lib/drawable/Events';
 import { State } from '@renderer/lib/drawable/State';
 import { Transition } from '@renderer/lib/drawable/Transition';
-import { Action } from '@renderer/types/diagram';
+import { Action, Event } from '@renderer/types/diagram';
+import { defaultTransColor } from '@renderer/utils';
 
 import { CreateModal, CreateModalResult } from './CreateModal';
 import { DiagramContextMenu } from './DiagramContextMenu';
-import { EventsModalData, EventsModal, EventsModalResult } from './EventsModal';
+import { EventsModalData, EventsModal } from './EventsModal';
 import { StateNameModal } from './StateNameModal';
-
-// цвет связи по-умолчанию
-export const defaultTransColor = '#0000FF';
 
 export interface DiagramEditorProps {
   manager: EditorManager;
@@ -35,6 +34,11 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
 
     const [isEventsModalOpen, openEventsModal, closeEventsModal] = useModal(false);
     const [eventsModalData, setEventsModalData] = useState<EventsModalData>();
+    // Дополнительные данные о родителе события
+    const [eventsModalParentData, setEventsModalParentData] = useState<{
+      state: State;
+      eventSelection: EventSelection;
+    }>();
 
     const contextMenu = useDiagramContextMenu(editor, manager);
     const stateName = useDiagramStateName(editor);
@@ -70,8 +74,11 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
       });
 
       editor.container.statesController.on('changeEvent', (data) => {
+        const { state, eventSelection, event, isEditingEvent } = data;
+
         ClearUseState();
-        setEventsModalData(data);
+        setEventsModalParentData({ state, eventSelection });
+        setEventsModalData({ event, isEditingEvent });
         openEventsModal();
       });
 
@@ -104,13 +111,32 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
       // }, [ containerRef.current ]);
     }, [manager, setEditor]);
 
-    const handleCreateEventsModal = (data: EventsModalResult) => {
-      setEvents([...events, data.action]);
-      if (!isCreateModalOpen && data.id?.eventSelection) {
+    const handleEventsModalSubmit = (data: Event) => {
+      // Если есть какие-то данные то мы редактируем событие а не добавляем
+      if (eventsModalData) {
+        setEvents((p) => {
+          const { component, method } = eventsModalData.event;
+          const prevEventIndex = p.findIndex(
+            (v) => v.component === component && v.method === method
+          );
+
+          if (prevEventIndex === -1) return p;
+
+          const newEvents = [...p];
+
+          newEvents[prevEventIndex] = data;
+
+          return newEvents;
+        });
+      } else {
+        setEvents((p) => [...p, data]);
+      }
+
+      if (!isCreateModalOpen && eventsModalParentData) {
         editor?.container.machineController.changeEvent(
-          data.id?.state.id,
-          data.id.eventSelection,
-          data.trigger
+          eventsModalParentData.state.id,
+          eventsModalParentData.eventSelection,
+          data
         );
       }
       closeEventsModal();
@@ -149,6 +175,13 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
       closeCreateModal();
     };
 
+    const handleOpenEventsModal = (event?: Event) => {
+      setEventsModalData(event && { event, isEditingEvent: false });
+      setEventsModalParentData(undefined);
+
+      openEventsModal();
+    };
+
     return (
       <>
         <div className="relative h-full overflow-hidden bg-neutral-800" ref={containerRef} />
@@ -161,7 +194,7 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
             editor={editor}
             manager={manager}
             initialData={eventsModalData}
-            onSubmit={handleCreateEventsModal}
+            onSubmit={handleEventsModalSubmit}
             isOpen={isEventsModalOpen}
             onClose={closeEventsModal}
           />
@@ -174,10 +207,7 @@ export const DiagramEditor: React.FC<DiagramEditorProps> = memo(
             isCondition={events}
             setIsCondition={setEvents}
             isOpen={isCreateModalOpen}
-            onOpenEventsModal={() => {
-              openEventsModal();
-              setEventsModalData(undefined);
-            }}
+            onOpenEventsModal={handleOpenEventsModal}
             isData={state}
             isTransition={transition ? { target: transition } : undefined}
             onClose={closeCreateModal}

--- a/src/renderer/src/lib/data/StatesController.ts
+++ b/src/renderer/src/lib/data/StatesController.ts
@@ -1,5 +1,6 @@
 import throttle from 'lodash.throttle';
 
+import { Event } from '@renderer/types/diagram';
 import { Point } from '@renderer/types/graphics';
 import { MyMouseEvent } from '@renderer/types/mouse';
 
@@ -26,7 +27,12 @@ interface StatesControllerEvents {
   changeState: State;
   changeStateName: State;
   stateContextMenu: { state: State; position: Point };
-  changeEvent: { state: State; eventSelection: EventSelection };
+  changeEvent: {
+    state: State;
+    eventSelection: EventSelection;
+    event: Event;
+    isEditingEvent: boolean;
+  };
   eventContextMenu: { state: State; event: EventSelection; position: Point };
 }
 
@@ -83,7 +89,14 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
       if (!eventSelection) {
         this.emit('changeState', state);
       } else {
-        this.emit('changeEvent', { state, eventSelection });
+        const eventData = state.eventBox.data[eventSelection.eventIdx];
+        const event =
+          eventSelection.actionIdx === null
+            ? eventData.trigger
+            : eventData.do[eventSelection.actionIdx];
+        const isEditingEvent = eventSelection.actionIdx === null;
+
+        this.emit('changeEvent', { state, eventSelection, event, isEditingEvent });
       }
     }
   };

--- a/src/renderer/src/utils/index.ts
+++ b/src/renderer/src/utils/index.ts
@@ -77,3 +77,6 @@ export const formatArgType = (value: ArgType) => {
 
   return value;
 };
+
+// цвет связи по-умолчанию
+export const defaultTransColor = '#0000FF';


### PR DESCRIPTION
Что сделано:
- EventsModal отцепился от состояния, раньше EventsModal принимал состояние (state) и сам из него вытаскивал данные с помощью eventSelection. Но так не получается редактировать события в переходе. Теперь EventsModal принимает сам объект события (event) и флаг isEditingEvent. То есть теперь модалке без разницы кто владеет событием
- В DiagramEditor усложнилась логика работы с редактированием событий, приходится хранить и использовать eventsModalParentData если у события есть родитель. В противном случае просто класть или редактировать событие в промежуточном состоянии events
- Добавлена возможность редактирования событий при редактировании состояния или перехода по двойному клику
- defaultTransColor перенесён в utils. Eslint ругался что экспорт чего-то другого вместе с компонентом ломает FastRefresh и на самом деле после переноса редактор перестал сбрасываться при изменении кода

Closes #129 