### PR TITLE
Исправление ошибки подключения к локальному загрузчику

### DIFF
--- a/src/renderer/src/components/Sidebar/Loader.tsx
+++ b/src/renderer/src/components/Sidebar/Loader.tsx
@@ -200,8 +200,8 @@ export const Loader: React.FC<FlasherProps> = ({ compilerData }) => {
   useEffect(() => {
     if (!flasherSetting) return;
     const { host, port, localPort, type } = flasherSetting;
-    if (type == 'local' && port != localPort) {
-      setFlasherSetting({ ...flasherSetting, ...{ port: localPort } }).then(() => {
+    if (type === 'local' && port !== localPort) {
+      setFlasherSetting({ ...flasherSetting, port: localPort }).then(() => {
         Flasher.connect(host, localPort);
       });
     } else {

--- a/src/renderer/src/components/Sidebar/Loader.tsx
+++ b/src/renderer/src/components/Sidebar/Loader.tsx
@@ -201,9 +201,12 @@ export const Loader: React.FC<FlasherProps> = ({ compilerData }) => {
     if (!flasherSetting) return;
     const { host, port, localPort, type } = flasherSetting;
     if (type == 'local' && port != localPort) {
-      setFlasherSetting({ ...flasherSetting, ...{ port: localPort } });
+      setFlasherSetting({ ...flasherSetting, ...{ port: localPort } }).then(() => {
+        Flasher.connect(host, localPort);
+      });
+    } else {
+      Flasher.connect(host, port);
     }
-    Flasher.connect(host, port);
   }, [flasherSetting, setFlasherSetting]);
 
   const display = () => {


### PR DESCRIPTION
Исправление сразу двух багов: отсутствие подключение к локальному загрузчику при первом запуске IDE (когда значения в electron-settings заданы по-умолчанию)  и невозможность при этом снова подключиться через перезапуск локального загрузчика.
Является решением этой проблемы: https://github.com/kruzhok-team/lapki-client/issues/286