### PR TITLE
Фикс: При отмене редактирования и удалении заметки сыпет ошибки в консоль

### DIFF
--- a/src/renderer/src/components/NoteEdit.tsx
+++ b/src/renderer/src/components/NoteEdit.tsx
@@ -12,7 +12,8 @@ export const NoteEdit: React.FC = () => {
   const editor = useEditorContext();
 
   const [isOpen, open, close] = useModal(false);
-  const [note, setNote] = useState<Note | null>(null);
+  const [noteId, setNoteId] = useState<string | null>(null);
+  const [initialText, setInitialText] = useState<string | null>(null);
   const [style, setStyle] = useState({} as CSSProperties);
   const ref = useRef<HTMLSpanElement>(null);
 
@@ -20,17 +21,21 @@ export const NoteEdit: React.FC = () => {
     const el = ref.current;
     const value = (el?.textContent ?? '').trim();
 
-    if (!el || !note || note.data.text === value) return;
+    if (!el || noteId === null || initialText === value) return;
 
-    editor.controller.notes.changeNoteText(note.id, value);
-  }, [editor, note]);
+    editor.controller.notes.changeNoteText(noteId, value);
+
+    setNoteId(null);
+    setInitialText(null);
+  }, [editor.controller.notes, initialText, noteId]);
 
   const handleClose = useCallback(() => {
     handleSubmit();
-    note?.setVisible(true);
+
+    if (noteId) editor.controller.notes.setIsVisible(noteId, true);
 
     close();
-  }, [close, handleSubmit, note]);
+  }, [close, editor.controller.notes, handleSubmit, noteId]);
 
   useEffect(() => {
     window.addEventListener('wheel', handleClose);
@@ -51,9 +56,10 @@ export const NoteEdit: React.FC = () => {
       const { width } = note.drawBounds;
       const { padding, fontSize, borderRadius } = note.computedStyles;
 
-      note.setVisible(false);
+      editor.controller.notes.setIsVisible(note.id, false);
 
-      setNote(note);
+      setNoteId(note.id);
+      setInitialText(note.data.text);
       setStyle({
         left: position.x + 'px',
         top: position.y + 'px',

--- a/src/renderer/src/lib/data/EditorController/NotesController.ts
+++ b/src/renderer/src/lib/data/EditorController/NotesController.ts
@@ -112,6 +112,15 @@ export class NotesController extends EventEmitter<NotesControllerEvents> {
     this.view.isDirty = true;
   }
 
+  setIsVisible(id: string, isVisible: boolean) {
+    const note = this.items.get(id);
+    if (!note) return;
+
+    note.setVisible(isVisible);
+
+    this.app.view.isDirty = true;
+  }
+
   handleMouseDown = (note: Note) => {
     this.controller.selectNote(note.id);
   };

--- a/src/renderer/src/lib/drawable/Note.ts
+++ b/src/renderer/src/lib/drawable/Note.ts
@@ -64,9 +64,11 @@ export class Note extends Shape {
     this.isSelected = value;
   }
 
+  /**
+   * Не рекомендуется делать это в обход контроллера
+   */
   setVisible(value: boolean) {
     this.visible = value;
-    this.app.view.isDirty = true;
   }
 
   prepareText() {


### PR DESCRIPTION
Проблема была в том что NoteEdit хранил ссылку на заметку при ее редактировании. После удаления заметки из хранилища обьект не удалялся потому что на него есть ссылка в NoteEdit, поэтому NoteEdit думал что заметка все еще существует.
Переделал на хранение id и текста.

Closes #321 