### PR TITLE
Фикс: Дублирование перехода внутри дерева Children после линковки

### DIFF
--- a/src/renderer/src/lib/data/EditorController/StatesController.ts
+++ b/src/renderer/src/lib/data/EditorController/StatesController.ts
@@ -276,6 +276,12 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
     child.parent = parent;
     parent.children.add(child, Layer.States);
 
+    // Перелинковка переходов
+    //! Нужно делать до создания перехода из начального состояния
+    this.controller.transitions.forEachByStateId(childId, (transition) => {
+      this.controller.transitions.linkTransition(transition.id);
+    });
+
     // Если не было начального состояния, им станет новое
     if (canBeInitial && this.getSiblings(child.id, child.data.parentId, 'states').length === 0) {
       this.changeStatePosition(
@@ -287,10 +293,6 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
       this.createInitialStateWithTransition(child.id, canUndo);
       numberOfConnectedActions += 2;
     }
-
-    this.controller.transitions.forEachByStateId(childId, (transition) => {
-      this.controller.transitions.linkTransition(transition.id);
-    });
 
     if (canUndo) {
       this.history.do({

--- a/src/renderer/src/lib/data/EditorController/TransitionsController.ts
+++ b/src/renderer/src/lib/data/EditorController/TransitionsController.ts
@@ -133,6 +133,7 @@ export class TransitionsController extends EventEmitter<TransitionsControllerEve
     // Убираем из предыдущего родителя
     transition.source.parent?.children.remove(transition, Layer.Transitions);
     transition.target.parent?.children.remove(transition, Layer.Transitions);
+    this.view.children.remove(transition, Layer.Transitions);
 
     if (!transition.source.parent || !transition.target.parent) {
       this.view.children.add(transition, Layer.Transitions);


### PR DESCRIPTION
Если создать переход на самом верхем уровне, а потом присоеденить состояние к которому он относится то при перелинковке перехода, он задублирвется.
Добавил удаление из верхнего уровня при перелинковке