### PR TITLE
UTF-8 кодировка для терминала vscode на windows

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -18,5 +18,12 @@
   "eslint.enable": true,
   "editor.codeActionsOnSave": {
     "source.fixAll": "explicit"
+  },
+  "terminal.integrated.profiles.windows": {
+    "PowerShell": {
+      "source": "PowerShell",
+      "icon": "terminal-powershell",
+      "args": ["-noexit", "chcp 65001"]
+    }
   }
 }


### PR DESCRIPTION
Вывовд от загрузчика выглядит вот так при использовании стандартной кодировки 
![image](https://github.com/kruzhok-team/lapki-client/assets/86153878/4a2bb4dc-a285-4580-825d-6f7abe3b2214)

Были предприняты попытки исправить проблему через код с использованием библиотек iconv-lite и node-iconv, но это не помогло, к тому же это требует установки дополнительных библиотек.

Поэтому было принято решение поменять кодировку терминала на UTF-8 через настройки vscode. 
![image](https://github.com/kruzhok-team/lapki-client/assets/86153878/92b89bd1-fcb3-4000-8551-e2a45fe6c831)