### PR TITLE
Выделение кнопки "Консоль" и небольшой редизайн экрана ошибки;

### DIFF
--- a/src/renderer/src/assets/styles/preload.css
+++ b/src/renderer/src/assets/styles/preload.css
@@ -1,5 +1,5 @@
 :root {
-  --loading-opacity: 60%;
+  --loading-opacity: 80%;
 }
 
 .loading-overlay {

--- a/src/renderer/src/assets/styles/preload.css
+++ b/src/renderer/src/assets/styles/preload.css
@@ -1,5 +1,5 @@
 :root {
-  --loading-opacity: 80%;
+  --loading-opacity: 90%;
 }
 
 .loading-overlay {
@@ -73,7 +73,7 @@
 
 @keyframes loadingFadeBg {
   from {
-    opacity: 0;
+    opacity: 50%;
   }
   to {
     opacity: var(--loading-opacity);

--- a/src/renderer/src/components/WhoopsieScreen.tsx
+++ b/src/renderer/src/components/WhoopsieScreen.tsx
@@ -39,25 +39,26 @@ export class WhoopsieScreen extends Component<WhoopsieScreenProps, WhoopsieScree
 
   render() {
     if (this.state.hasError) {
-      // TODO: сделать более понятный экран для пользователей
-      const buttonStyle = 'text-2xl text-white rounded-md bg-slate-600 p-1 w-[200px]';
       return (
         <div className="loading-overlay">
           <div className="flex select-none flex-col items-center text-white">
             <CatError />
-            <p className="text-3xl italic ">Хьюстон, срочно проверьте лоток</p>
-            <p className="text-sm italic">
+            <p className="text-3xl">Хьюстон, срочно проверьте лоток</p>
+            <p className="text-base">
               Lapki IDE сделала что-то не то, подробности в{' '}
-              <a className="font-bold" onClick={() => this.openDevTools()}>
+              <a
+                className="rounded border bg-gray-600 px-1 hover:bg-gray-700"
+                onClick={() => this.openDevTools()}
+              >
                 консоли
               </a>
             </p>
             <br />
-            <button onClick={() => this.unwhoopsie()} className={buttonStyle}>
+            <button onClick={() => this.unwhoopsie()} className="btn-primary w-48 text-xl">
               Игнорировать
             </button>
-            <p className="pb-1 text-xs italic">(не рекомендуется)</p>
-            <button onClick={() => location.reload()} className={buttonStyle}>
+            <p className="pb-2 text-sm">(не рекомендуется)</p>
+            <button onClick={() => location.reload()} className="btn-primary w-48 text-xl">
               Перезапуск
             </button>
           </div>

--- a/src/renderer/src/components/WhoopsieScreen.tsx
+++ b/src/renderer/src/components/WhoopsieScreen.tsx
@@ -59,7 +59,7 @@ export class WhoopsieScreen extends Component<WhoopsieScreenProps, WhoopsieScree
             </button>
             <p className="pb-2 text-sm">(не рекомендуется)</p>
             <button onClick={() => location.reload()} className="btn-primary w-48 text-xl">
-              Перезапуск
+              Перезапустить
             </button>
           </div>
         </div>

--- a/src/renderer/src/components/WhoopsieScreen.tsx
+++ b/src/renderer/src/components/WhoopsieScreen.tsx
@@ -39,6 +39,7 @@ export class WhoopsieScreen extends Component<WhoopsieScreenProps, WhoopsieScree
 
   render() {
     if (this.state.hasError) {
+      // TODO: сделать более понятный экран для пользователей
       return (
         <div className="loading-overlay">
           <div className="flex select-none flex-col items-center text-white">

--- a/src/renderer/src/components/WhoopsieScreen.tsx
+++ b/src/renderer/src/components/WhoopsieScreen.tsx
@@ -43,11 +43,11 @@ export class WhoopsieScreen extends Component<WhoopsieScreenProps, WhoopsieScree
         <div className="loading-overlay">
           <div className="flex select-none flex-col items-center text-white">
             <CatError />
-            <p className="text-3xl">Хьюстон, срочно проверьте лоток</p>
-            <p className="text-base">
+            <p className="text-3xl italic">Хьюстон, срочно проверьте лоток</p>
+            <p className="text-base italic">
               Lapki IDE сделала что-то не то, подробности в{' '}
               <a
-                className="rounded border bg-gray-600 px-1 hover:bg-gray-700"
+                className="rounded border bg-gray-600 px-1 hover:cursor-pointer hover:bg-gray-700"
                 onClick={() => this.openDevTools()}
               >
                 консоли


### PR DESCRIPTION
1) Была исправлена прозрачность с 60% на 80% для того, чтобы экран ошибки не был сильно тусклым;
2) Исправлены стили кнопок и стили текста под стандарт IDE;
3) Выделена кнопка "Консоль".

Было: 
![image](https://github.com/kruzhok-team/lapki-client/assets/135246322/baa6dc16-f4c7-480f-97c3-128afd303da3)
Стало:
![image](https://github.com/kruzhok-team/lapki-client/assets/135246322/9411d87a-6b4b-468d-9cf0-7bd30d00a101)

closes #347 