### PR TITLE
Исправление таймаута компилятора

### DIFF
--- a/src/renderer/src/components/Modules/Compiler.ts
+++ b/src/renderer/src/components/Modules/Compiler.ts
@@ -276,6 +276,7 @@ export class Compiler extends ClientWS {
   }
 
   static closeHandler(host: string, port: number, event: Websocket.CloseEvent) {
+    this.timeoutTimer.clear();
     if (!event.wasClean) {
       toast.error('Ошибка при подключении к компилятору');
     }

--- a/src/renderer/src/components/Modules/Compiler.ts
+++ b/src/renderer/src/components/Modules/Compiler.ts
@@ -217,7 +217,12 @@ export class Compiler extends ClientWS {
 
         this.onStatusChange(CompilerStatus.COMPILATION);
         this.timeoutTimer.timeOut(() => {
-          this.onStatusChange(CompilerStatus.SOMETHING_WRONG);
+          toast.error('Превышено время ожидания компиляции');
+          // возращаем статут соединения, если соединение присутствует
+          // если оно пропало, то статус изменится самостоятельно, то есть тут ничего менять не надо
+          if (this.connection && this.connection.OPEN) {
+            this.onStatusChange(CompilerStatus.CONNECTED);
+          }
         });
       } else {
         console.error('Внутренняя ошибка! Отсутствует подключение');

--- a/src/renderer/src/components/Modules/Compiler.ts
+++ b/src/renderer/src/components/Modules/Compiler.ts
@@ -187,6 +187,7 @@ export class Compiler extends ClientWS {
   }
 
   static async compile(platform: string, data: Elements | string) {
+    this.setCompilerData(undefined);
     this.platform = platform;
     await this.connect(this.host, this.port).then((ws: Websocket | undefined) => {
       if (ws !== undefined) {

--- a/src/renderer/src/components/Modules/Websocket/ClientStatus.ts
+++ b/src/renderer/src/components/Modules/Websocket/ClientStatus.ts
@@ -8,3 +8,8 @@ export class ClientStatus {
 export class CompilerStatus extends ClientStatus {
   static COMPILATION: string = 'Идет компиляция...';
 }
+
+export class CompilerNoDataStatus {
+  static DEFAULT: string = 'Нет данных';
+  static TIMEOUT: string = 'Превышено время ожидания компиляции';
+}

--- a/src/renderer/src/components/Modules/Websocket/ClientStatus.ts
+++ b/src/renderer/src/components/Modules/Websocket/ClientStatus.ts
@@ -7,5 +7,4 @@ export class ClientStatus {
 
 export class CompilerStatus extends ClientStatus {
   static COMPILATION: string = 'Идет компиляция...';
-  static SOMETHING_WRONG: string = 'Что-то пошло не так...';
 }

--- a/src/renderer/src/components/Sidebar/Compiler.tsx
+++ b/src/renderer/src/components/Sidebar/Compiler.tsx
@@ -12,7 +12,7 @@ import { CompilerResult } from '@renderer/types/CompilerTypes';
 import { Elements } from '@renderer/types/diagram';
 import { languageMappers } from '@renderer/utils';
 
-import { CompilerStatus } from '../Modules/Websocket/ClientStatus';
+import { CompilerStatus, CompilerNoDataStatus } from '../Modules/Websocket/ClientStatus';
 
 export interface CompilerProps {
   openData: [boolean, string | null, string | null, string] | undefined;
@@ -36,6 +36,9 @@ export const CompilerTab: React.FC<CompilerProps> = ({
 
   const [compilerSetting] = useSettings('compiler');
   const [importData, setImportData] = useState<Elements | undefined>(undefined);
+  const [compilerNoDataStatus, setCompilerNoDataStatus] = useState<string>(
+    CompilerNoDataStatus.DEFAULT
+  );
   const openTab = useTabs((state) => state.openTab);
   const changeSidebarTab = useSidebar((state) => state.changeTab);
 
@@ -108,7 +111,7 @@ export const CompilerTab: React.FC<CompilerProps> = ({
 
     const { host, port } = compilerSetting;
 
-    Compiler.bindReact(setCompilerData, setCompilerStatus, setImportData);
+    Compiler.bindReact(setCompilerData, setCompilerStatus, setImportData, setCompilerNoDataStatus);
     Compiler.connect(host, port);
   }, [compilerSetting]);
 
@@ -185,7 +188,7 @@ export const CompilerTab: React.FC<CompilerProps> = ({
         </p>
 
         <div className="mb-4 min-h-[350px] select-text overflow-y-auto break-words rounded bg-bg-primary p-2">
-          Результат компиляции: {compilerData ? compilerData.result : 'Нет данных'}
+          Результат компиляции: {compilerData ? compilerData.result : compilerNoDataStatus}
         </div>
 
         {button.map(({ name, handler, disabled }, i) => (


### PR DESCRIPTION
При достижении таймаута на клиентской части компилятора, статус соединения менялся на "что пошло не так...", что блокировало кнопку "скомпилировать".

Этот PR меняет поведение при таймауте, теперь статус соединения не меняется, но всплывает ошибка, а также появляется сообщение в поле "Результат компиляции" о таймауте. 