### PR TITLE
Удаление фразы 'Пока что нет описания' 

### DIFF
--- a/src/renderer/src/components/CreateSchemeModal/PlatformSelection.tsx
+++ b/src/renderer/src/components/CreateSchemeModal/PlatformSelection.tsx
@@ -40,7 +40,10 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({
         ))}
       </div>
 
-      <div>{selectedPlatform?.description || ''}</div>
+      <div className={twMerge(selectedPlatform?.description ?? 'opacity-70')}>
+        {selectedPlatform?.description ||
+          'Для начала работы выберите платформу из списка слева. Платформа определяет, для чего создаётся схема и с помощью каких элементов.'}
+      </div>
     </div>
   );
 };

--- a/src/renderer/src/components/CreateSchemeModal/PlatformSelection.tsx
+++ b/src/renderer/src/components/CreateSchemeModal/PlatformSelection.tsx
@@ -40,7 +40,7 @@ export const PlatformSelection: React.FC<PlatformSelectionProps> = ({
         ))}
       </div>
 
-      <div>{selectedPlatform?.description || 'Пока что нет описания'}</div>
+      <div>{selectedPlatform?.description || ''}</div>
     </div>
   );
 };


### PR DESCRIPTION
При отсутствии схемы описания нет и его не должно быть, фраза 'Пока что нет описания' вводит в заблуждение. Лучше если на месте описания ничего не будет написано.
![image](https://github.com/user-attachments/assets/94fd6d87-7db7-473a-bf5d-e7f88deabbaa)
![image](https://github.com/user-attachments/assets/9bea6c76-1665-4050-a2dc-345c743046ce)
