### PR TITLE
Исправление автоматического подключения к локальному загрузчику

### DIFF
--- a/src/renderer/src/components/Modules/Flasher.ts
+++ b/src/renderer/src/components/Modules/Flasher.ts
@@ -83,7 +83,7 @@ export class Flasher extends ClientWS {
     this.setErrorMessage = setErrorMessage;
     this.setFlashResult = setFlashResult;
   }
-  /*
+  /**
     Добавляет устройство в список устройств
 
     @param {device} устройство для добавления
@@ -113,7 +113,6 @@ export class Flasher extends ClientWS {
     });
   }
 
-  // обновление порта (только для ArduinoDevice)
   /**
    * обновление порта (сообщение приходит только для {@link ArduinoDevice})
    * @param port сообщение от сервера об обновлении порта

--- a/src/renderer/src/components/Modules/Websocket/ClientWS.ts
+++ b/src/renderer/src/components/Modules/Websocket/ClientWS.ts
@@ -40,9 +40,13 @@ export abstract class ClientWS {
   /**
    * подключение к заданному хосту и порту, отключается от предыдущего адреса
    */
-  static async connect(host: string, port: number): Promise<Websocket | undefined> {
+  static async connect(
+    host: string,
+    port: number,
+    autoReconnect: boolean = true
+  ): Promise<Websocket | undefined> {
     if (!this.isEqualAdress(host, port)) {
-      this.initOrResetReconnectTimer();
+      this.initOrResetReconnectTimer(autoReconnect);
       // чтобы предовратить повторное соединение
     } else if (
       this.connection &&
@@ -71,6 +75,7 @@ export abstract class ClientWS {
     }
 
     ws.onopen = () => {
+      this.initOrResetReconnectTimer(autoReconnect);
       this.onOpenHandler();
     };
 
@@ -125,7 +130,6 @@ export abstract class ClientWS {
   }
 
   static onOpenHandler() {
-    this.initOrResetReconnectTimer();
     //console.log(`Client: connected to ${this.host}:${this.port}!`);
     this.onStatusChange(ClientStatus.CONNECTED);
     this.setSecondsUntilReconnect(null);
@@ -140,11 +144,12 @@ export abstract class ClientWS {
     return host == this.host && port == this.port;
   }
 
-  static initOrResetReconnectTimer() {
+  static initOrResetReconnectTimer(autoReconnect: boolean = true) {
     if (this.reconnectTimer) {
-      this.reconnectTimer.reset();
+      this.reconnectTimer.reset(autoReconnect);
     } else {
       this.reconnectTimer = new ReconnectTimer();
+      this.reconnectTimer.setAutoReconnect(autoReconnect);
     }
   }
 

--- a/src/renderer/src/components/Sidebar/Loader.tsx
+++ b/src/renderer/src/components/Sidebar/Loader.tsx
@@ -253,12 +253,13 @@ export const Loader: React.FC<FlasherProps> = ({
   useEffect(() => {
     if (!flasherSetting) return;
     const { host, port, localPort, type } = flasherSetting;
+    const autoReconnect = type === 'remote';
     if (type === 'local' && port !== localPort) {
       setFlasherSetting({ ...flasherSetting, port: localPort }).then(() => {
-        Flasher.connect(host, localPort);
+        Flasher.connect(host, localPort, autoReconnect);
       });
     } else {
-      Flasher.connect(host, port);
+      Flasher.connect(host, port, autoReconnect);
     }
   }, [flasherSetting, setFlasherSetting]);
 

--- a/src/renderer/src/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar/Sidebar.tsx
@@ -81,7 +81,6 @@ export const Sidebar: React.FC<SidebarProps> = ({
   const handleFlasherModalSubmit = (data: FlasherSelectModalFormValues) => {
     if (!flasherSetting) return;
 
-    Flasher.setAutoReconnect(data.type === 'remote');
     setFlasherSetting({ ...flasherSetting, ...data });
   };
 


### PR DESCRIPTION
При падении локального загрузчика, клиент не должен автоматически пытаться подключиться к нему. Он просто должен дать пользователю кнопку "перезапустить". Этот PR исправляет ситуацию, когда клиент пытается подключиться к нерабочему локальному загрузчику.