### PR TITLE
Снятие удаления МС по нажатию на прав. кн. мыши

### DIFF
--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -43,7 +43,7 @@ export const StateMachinesList: React.FC = () => {
     editProps,
     deleteProps,
     // onSwapStateMachines
-    onRequestDeleteStateMachine,
+    // onRequestDeleteStateMachine,
     onRequestAddStateMachine,
     onRequestEditStateMachine,
     isDuplicateName,

--- a/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
+++ b/src/renderer/src/components/Sidebar/StateMachinesTab/StateMachinesList.tsx
@@ -76,7 +76,7 @@ export const StateMachinesList: React.FC = () => {
               isSelected={id === selectedSm}
               onSelect={() => setSmSelected(id)}
               onEdit={() => onRequestEditStateMachine(id)}
-              onDelete={() => onRequestDeleteStateMachine(id)}
+              onDelete={() => undefined}
               onCallContextMenu={() => onCallContextMenu(id, sm)}
               // TODO (L140-beep): Доделать свап машин состояний
               onDragStart={() => console.log('setDragState')}


### PR DESCRIPTION
При нажатии на машину состояния правой кнопкой мыши триггерятся два действия - запрос на удаление и открытие вкладки со схемой машины состояния. Этот PR, убирает удаление при нажатии на правую кнопку мыши, что позволяет открыть вкладку с машиной состояния.