### PR TITLE
Фикс биндинга EdgeHandlers, фикс бага с инициализацией псевдосостояний выбора

### DIFF
--- a/src/renderer/src/lib/data/Initializer.ts
+++ b/src/renderer/src/lib/data/Initializer.ts
@@ -54,7 +54,7 @@ export class Initializer {
    */
   initStates(smId: string, states: { [id: string]: DataState }) {
     for (const id in states) {
-      this.states.createState({ smId, id: id, ...states[id] });
+      this.states.initState({ smId, id: id, ...states[id] });
     }
 
     for (const id in states) {

--- a/src/renderer/src/lib/data/ModelController/CanvasController.ts
+++ b/src/renderer/src/lib/data/ModelController/CanvasController.ts
@@ -541,7 +541,7 @@ export class CanvasController extends EventEmitter<CanvasControllerEvents> {
           'changeChoicePosition',
           this.bindHelper('choice', 'changeChoicePosition', this.states.changeChoiceStatePosition)
         );
-        this.initializer.initFinalStates(smId, initData as { [id: string]: FinalState });
+        this.initializer.initChoiceStates(smId, initData as { [id: string]: ChoiceState });
         break;
       case 'note':
         this.model.on('createNote', this.bindHelper('note', 'createNote', this.notes.createNote));

--- a/src/renderer/src/lib/data/ModelController/ModelController.ts
+++ b/src/renderer/src/lib/data/ModelController/ModelController.ts
@@ -1642,7 +1642,7 @@ export class ModelController extends EventEmitter<ModelControllerEvents> {
     this.emit('deleteChoice', args);
   }
 
-  changeFinalStatePosition(args: ChangePosition, canUndo = true) {
+  changeFinalStatePosition = (args: ChangePosition, canUndo = true) => {
     this.model.changeFinalStatePosition(args.smId, args.id, args.endPosition);
     this.emit('changeFinalStatePosition', args);
     const { startPosition } = args;
@@ -1652,7 +1652,7 @@ export class ModelController extends EventEmitter<ModelControllerEvents> {
         args: { ...args, startPosition: startPosition },
       });
     }
-  }
+  };
 
   changeChoiceStatePosition = (args: ChangePosition, canUndo = true) => {
     this.model.changeChoiceStatePosition(args.smId, args.id, args.endPosition);

--- a/src/renderer/src/lib/data/ModelController/NotesController.ts
+++ b/src/renderer/src/lib/data/ModelController/NotesController.ts
@@ -44,7 +44,7 @@ export class NotesController extends EventEmitter<NotesControllerEvents> {
   clear = this.items.clear.bind(this.items);
   forEach = this.items.forEach.bind(this.items);
 
-  createNote = (params: CreateNoteParams) => {
+  initNote = (params: CreateNoteParams) => {
     const { id, smId } = params;
     if (!id) return;
     const note = new Note(this.app, smId, id, { ...params });
@@ -54,6 +54,15 @@ export class NotesController extends EventEmitter<NotesControllerEvents> {
     this.view.children.add(note, Layer.Notes);
 
     this.view.isDirty = true;
+
+    return note;
+  };
+
+  createNote = (params: CreateNoteParams) => {
+    const note = this.initNote(params);
+    if (!note) return;
+
+    this.bindEdgeHandlers(note);
   };
 
   changeNoteText = (args: ChangeNoteText) => {

--- a/src/renderer/src/lib/data/ModelController/StatesController.ts
+++ b/src/renderer/src/lib/data/ModelController/StatesController.ts
@@ -305,7 +305,7 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
     this.view.isDirty = true;
   };
 
-  createChoiceState = (params: CreateChoiceStateParams) => {
+  initChoiceState = (params: CreateChoiceStateParams) => {
     const { id, smId } = params;
     if (!id) return;
     const state = new ChoiceState(this.app, id, smId, { ...params });
@@ -317,6 +317,14 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
     this.watch(state);
 
     this.view.isDirty = true;
+    return state;
+  };
+
+  createChoiceState = (params: CreateChoiceStateParams) => {
+    const state = this.initChoiceState(params);
+    if (!state) return;
+
+    this.bindEdgeHandlers(state);
   };
 
   deleteChoiceState = (args: DeleteDrawableParams) => {

--- a/src/renderer/src/lib/data/ModelController/StatesController.ts
+++ b/src/renderer/src/lib/data/ModelController/StatesController.ts
@@ -131,7 +131,7 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
     });
   }
 
-  createState = (args: CreateStateParams) => {
+  initState = (args: CreateStateParams) => {
     const { id, smId } = args;
 
     if (!id) return;
@@ -144,6 +144,15 @@ export class StatesController extends EventEmitter<StatesControllerEvents> {
     this.watch(state);
 
     this.view.isDirty = true;
+
+    return state;
+  };
+
+  createState = (args: CreateStateParams) => {
+    const state = this.initState(args);
+    if (!state) return;
+
+    this.bindEdgeHandlers(state);
   };
 
   changeStateName = (args: ChangeStateNameParams) => {


### PR DESCRIPTION
Суть бага: EdgeHandlers биндился только при инициализации данных, но не когда мы добавляли новые состояния и заметки на диаграмму, из-за этого не создавались переходы. Если же сохранить диаграмму в схеме, а потом заново открыть - то у нас происходит инициализация новых данных и поэтому все работает

close https://github.com/kruzhok-team/lapki-client/issues/488