### PR TITLE
Улучшения и исправления парсинга и валидации атрибутов как параметров

### DIFF
--- a/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
+++ b/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
@@ -97,6 +97,14 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
     });
   };
 
+  const setCheckedTo = (name: string, checked: boolean) => {
+    setIsChecked((oldValue) => {
+      const newValue = new Map(oldValue);
+      newValue.set(name, checked);
+      return newValue;
+    });
+  };
+
   if (protoParameters.length === 0) {
     return null;
     // return <div className="flex text-text-inactive">Параметров нет</div>;
@@ -156,7 +164,10 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
         const platform = controller.platform[smId].data;
         const componentAttibute = getComponentAttribute(value as string, platform);
         // в первый раз проверяет является ли записанное значение атрибутом, затем отслеживает нажатие на чекбокс
-        const currentChecked = isChecked.get(name) ?? componentAttibute != null;
+        const currentChecked = isChecked.get(name);
+        if (isChecked.get(name) === undefined) {
+          setCheckedTo(name, componentAttibute != null);
+        }
         const selectedParameterComponent =
           currentChecked && componentAttibute ? componentAttibute[0] : null;
         const selectedParameterMethod =
@@ -167,11 +178,7 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
             <Checkbox
               checked={currentChecked}
               onCheckedChange={() => {
-                setIsChecked((oldValue) => {
-                  const newValue = new Map(oldValue);
-                  newValue.set(name, !currentChecked);
-                  return newValue;
-                });
+                setCheckedTo(name, !currentChecked);
                 handleInputChange(name, type, '');
               }}
               className="mr-2 mt-[9px]"

--- a/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
+++ b/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
@@ -161,7 +161,7 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
               className="mr-2 mt-[9px]"
             />
             {currentChecked ? (
-              <div key={name}>
+              <div className="w-full">
                 <div className="flex">
                   <label className="grid grid-cols-[max-content,1fr] items-center justify-start gap-2">
                     <div className="flex min-w-28 items-center gap-1">
@@ -177,33 +177,35 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
                       )}
                     </div>
                   </label>
-                  <Select
-                    containerClassName="w-full"
-                    options={componentOptions}
-                    onChange={(opt) =>
-                      handleComponentAttributeChange(name, opt?.value ?? '', '', platform)
-                    }
-                    value={
-                      componentOptions.find((o) => o.value === selectedParameterComponent) ?? null
-                    }
-                    isSearchable={false}
-                    noOptionsMessage={() => 'Нет подходящих компонентов'}
-                  />
-                  <Select
-                    containerClassName="w-full"
-                    options={methodOptions}
-                    onChange={(opt) =>
-                      handleComponentAttributeChange(
-                        name,
-                        selectedParameterComponent ?? '',
-                        opt?.value ?? '',
-                        platform
-                      )
-                    }
-                    value={methodOptions.find((o) => o.value === selectedParameterMethod) ?? null}
-                    isSearchable={false}
-                    noOptionsMessage={() => 'Нет подходящих атрибутов'}
-                  />
+                  <div className="flex w-full">
+                    <Select
+                      containerClassName="w-full"
+                      options={componentOptions}
+                      onChange={(opt) =>
+                        handleComponentAttributeChange(name, opt?.value ?? '', '', platform)
+                      }
+                      value={
+                        componentOptions.find((o) => o.value === selectedParameterComponent) ?? null
+                      }
+                      isSearchable={false}
+                      noOptionsMessage={() => 'Нет подходящих компонентов'}
+                    />
+                    <Select
+                      containerClassName="w-full"
+                      options={methodOptions}
+                      onChange={(opt) =>
+                        handleComponentAttributeChange(
+                          name,
+                          selectedParameterComponent ?? '',
+                          opt?.value ?? '',
+                          platform
+                        )
+                      }
+                      value={methodOptions.find((o) => o.value === selectedParameterMethod) ?? null}
+                      isSearchable={false}
+                      noOptionsMessage={() => 'Нет подходящих атрибутов'}
+                    />
+                  </div>
                 </div>
                 <p className="pl-[120px] text-sm text-error">{error}</p>
               </div>

--- a/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
+++ b/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
@@ -159,16 +159,16 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
           }
         }
         const platform = controller.platform[smId].data;
-        const componentAttibute = getComponentAttribute(value as string, platform);
+        const componentAttribute = getComponentAttribute(value as string, platform);
         // в первый раз проверяет является ли записанное значение атрибутом, затем отслеживает нажатие на чекбокс
         const currentChecked = isChecked.get(name);
         if (isChecked.get(name) === undefined) {
-          setCheckedTo(name, componentAttibute != null);
+          setCheckedTo(name, componentAttribute != null);
         }
         const selectedParameterComponent =
-          currentChecked && componentAttibute ? componentAttibute[0] : null;
+          currentChecked && componentAttribute ? componentAttribute[0] : null;
         const selectedParameterMethod =
-          currentChecked && componentAttibute ? componentAttibute[1] : null;
+          currentChecked && componentAttribute ? componentAttribute[1] : null;
         const methodOptions = methodOptionsSearch(selectedParameterComponent);
         return (
           <div className="flex items-start" key={name}>

--- a/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
+++ b/src/renderer/src/components/NodeModal/ActionsModal/ActionsModalParameters.tsx
@@ -161,48 +161,50 @@ export const ActionsModalParameters: React.FC<ActionsModalParametersProps> = ({
               className="mr-2 mt-[9px]"
             />
             {currentChecked ? (
-              <div className="flex w-full gap-2" key={name}>
-                <label className="grid grid-cols-[max-content,1fr] items-center justify-start gap-2">
-                  <div className="flex min-w-28 items-center gap-1">
-                    <span>{label}</span>
-                    {hint && (
-                      <WithHint hint={hint}>
-                        {(props) => (
-                          <div className="shrink-0" {...props}>
-                            <QuestionMark className="h-5 w-5" />
-                          </div>
-                        )}
-                      </WithHint>
-                    )}
-                  </div>
-                </label>
-                <Select
-                  containerClassName="w-full"
-                  options={componentOptions}
-                  onChange={(opt) =>
-                    handleComponentAttributeChange(name, opt?.value ?? '', '', platform)
-                  }
-                  value={
-                    componentOptions.find((o) => o.value === selectedParameterComponent) ?? null
-                  }
-                  isSearchable={false}
-                  noOptionsMessage={() => 'Нет подходящих компонентов'}
-                />
-                <Select
-                  containerClassName="w-full"
-                  options={methodOptions}
-                  onChange={(opt) =>
-                    handleComponentAttributeChange(
-                      name,
-                      selectedParameterComponent ?? '',
-                      opt?.value ?? '',
-                      platform
-                    )
-                  }
-                  value={methodOptions.find((o) => o.value === selectedParameterMethod) ?? null}
-                  isSearchable={false}
-                  noOptionsMessage={() => 'Нет подходящих атрибутов'}
-                />
+              <div key={name}>
+                <div className="flex">
+                  <label className="grid grid-cols-[max-content,1fr] items-center justify-start gap-2">
+                    <div className="flex min-w-28 items-center gap-1">
+                      <span>{label}</span>
+                      {hint && (
+                        <WithHint hint={hint}>
+                          {(props) => (
+                            <div className="shrink-0" {...props}>
+                              <QuestionMark className="h-5 w-5" />
+                            </div>
+                          )}
+                        </WithHint>
+                      )}
+                    </div>
+                  </label>
+                  <Select
+                    containerClassName="w-full"
+                    options={componentOptions}
+                    onChange={(opt) =>
+                      handleComponentAttributeChange(name, opt?.value ?? '', '', platform)
+                    }
+                    value={
+                      componentOptions.find((o) => o.value === selectedParameterComponent) ?? null
+                    }
+                    isSearchable={false}
+                    noOptionsMessage={() => 'Нет подходящих компонентов'}
+                  />
+                  <Select
+                    containerClassName="w-full"
+                    options={methodOptions}
+                    onChange={(opt) =>
+                      handleComponentAttributeChange(
+                        name,
+                        selectedParameterComponent ?? '',
+                        opt?.value ?? '',
+                        platform
+                      )
+                    }
+                    value={methodOptions.find((o) => o.value === selectedParameterMethod) ?? null}
+                    isSearchable={false}
+                    noOptionsMessage={() => 'Нет подходящих атрибутов'}
+                  />
+                </div>
                 <p className="pl-[120px] text-sm text-error">{error}</p>
               </div>
             ) : (

--- a/src/renderer/src/utils/ComponentAttribute.ts
+++ b/src/renderer/src/utils/ComponentAttribute.ts
@@ -6,7 +6,12 @@ import { Platform } from '@renderer/types/platform';
  * @returns массив из трёх элементов, где первый - это компонент, второй - атрибут, а третий разделитель. Null, если строка не является параметром с атрибутом.
  */
 export const getComponentAttribute = (parameter: string, platform: Platform | undefined) => {
-  if (!platform || parameter.includes('"') || !isNaN(Number(parameter))) {
+  if (
+    !platform ||
+    parameter.includes('"') ||
+    parameter.includes("'") ||
+    !isNaN(Number(parameter))
+  ) {
     return null;
   }
   let delimiter = '.';


### PR DESCRIPTION
- Теперь все параметры проходят валидацию при отправке формы, а не при каждом изменение ввода, как это было раньше.
- Исправлен баг, когда при вводе символа '.' поле переключалось в режим атрибутов параметров.
- При парсинге параметра, проверяется, записан ли он при помощи символа кавычки `'` (это сделано для того, чтобы подобный текст `'.'` не считался за атрибут.
- При переключении поля в режим выбора атрибутов больше не появляется отступ.
- При отправке параметра как атрибута, проверяется наличие метода (чтобы нельзя было отправить что-то вроде `Counter1.`).
- При провале валидации, текст ошибки отображается не только для обычных полей ввода, но и для селекторов атрибутов-параметров.