### PR TITLE
Скрытие селектора МС при выборе файла

### DIFF
--- a/src/renderer/src/components/Sidebar/Loader.tsx
+++ b/src/renderer/src/components/Sidebar/Loader.tsx
@@ -501,18 +501,17 @@ export const Loader: React.FC<FlasherProps> = ({
                 из файла <span className="font-medium">{flasherFile}</span>
               </p>
             ) : (
-              ''
+              <Select
+                className="mb-2"
+                isSearchable={false}
+                placeholder="Выберите машину состояний..."
+                options={stateMachineOptions()}
+                value={getSelectMachineStateOption()}
+                onChange={(opt) => onSelectMachineState(opt?.value)}
+                isDisabled={currentDeviceID == undefined}
+                noOptionsMessage={() => 'Нет подходящих машин состояний'}
+              />
             )}
-            <Select
-              className="mb-2"
-              isSearchable={false}
-              placeholder="Выберите машину состояний..."
-              options={stateMachineOptions()}
-              value={getSelectMachineStateOption()}
-              onChange={(opt) => onSelectMachineState(opt?.value)}
-              isDisabled={currentDeviceID == undefined}
-              noOptionsMessage={() => 'Нет подходящих машин состояний'}
-            />
           </div>
         );
       } else {


### PR DESCRIPTION
Если селектор машин состояний и выбранный файл для прошивки присутствуют одновременно, то это может сбить с толку пользователя, ведь ему будет не понятно откуда будет браться прошивка.
Старый вид:
![image](https://github.com/user-attachments/assets/e986c9b1-031c-487c-b72b-3889d06cb96b)
Новый вид:
![image](https://github.com/user-attachments/assets/8adbf0d7-8e50-415b-a481-72d445468ea0)
