### PR TITLE
Фикс бага преобразования типа бинарных данных для загрузчика

### DIFF
--- a/src/renderer/src/components/Modules/Flasher.ts
+++ b/src/renderer/src/components/Modules/Flasher.ts
@@ -172,7 +172,11 @@ export class Flasher extends ClientWS {
     }
     for (const bin of binaries) {
       if (bin.extension.endsWith(ending)) {
-        return bin.fileContent as Blob;
+        if (bin.fileContent instanceof Blob) {
+          return bin.fileContent;
+        } else {
+          return new Blob([bin.fileContent]);
+        }
       }
     }
     return null;


### PR DESCRIPTION
Close https://github.com/kruzhok-team/lapki-client/issues/603

Всё ещё не понятно, почему тип `bin.fileContent` преобразуется в Buffer, ведь сохранение результата не должно влиять на бинарники, но тем не менее проблема решена.