### PR TITLE
Удаление значений по умолчанию в селекторах

### DIFF
--- a/src/renderer/src/components/ComponentFormFieldLabel.tsx
+++ b/src/renderer/src/components/ComponentFormFieldLabel.tsx
@@ -46,6 +46,7 @@ export const ComponentFormFieldLabel: React.FC<ComponentFormFieldLabelProps> = (
               className
             )}
             {...props}
+            value={props.value ?? ''}
           />
         )}
       </Component>

--- a/src/renderer/src/components/ComponentFormFields.tsx
+++ b/src/renderer/src/components/ComponentFormFields.tsx
@@ -119,7 +119,7 @@ export const ComponentFormFields: React.FC<ComponentFormFieldsProps> = ({
 
       {protoParametersArray.map(([idx, param]) => {
         const name = param.name ?? idx;
-        const value = parameters[name] ?? '';
+        const value: string | undefined = parameters[name];
         const type = allParameters[name].type;
         const error = errors[name];
 


### PR DESCRIPTION
Эти дефолтные значения были явно добавлены неумышленно, потому что появлялись они из-за того, что, если параметр отсутствует, он заменяется `пустой строкой`, которая затем кастилась к нулю в селекторе в отрыве от функций, которые прокидывали значение селектора вверх.
```jsx
<Select
  className="w-[250px]"
  options={options}
  value={options.find((o) => o.value === value || o.value === Number(value))}
  onChange={({ value }: any) => handleInputChange(name, value)}
/>
```

Теперь при создании компонента пользователя ожидают пустые селекторы, которые только и ждут, чтобы их явно заполнили.

close https://github.com/kruzhok-team/lapki-client/issues/592