### PR TITLE
Изменение стиля стрелок

### DIFF
--- a/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithLabel.ts
+++ b/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithLabel.ts
@@ -41,7 +41,7 @@ export class ArrowsWithLabel implements Drawable {
     ctx.fillStyle = fillStyle;
 
     if (!this.parent.isSelected) {
-      ctx.globalAlpha = 0.3;
+      ctx.globalAlpha = transitionStyle.notSelectedAlpha;
     }
     drawCurvedLine(ctx, sourceLine, 12 / this.app.controller.scale);
     drawCurvedLine(ctx, targetLine, 12 / this.app.controller.scale);

--- a/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithoutLabel.ts
+++ b/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithoutLabel.ts
@@ -35,8 +35,8 @@ export class ArrowsWithoutLabel implements Drawable {
     ctx.strokeStyle = this.parent.data.color ?? getColor('default-transition-color');
     ctx.fillStyle = fillStyle;
 
-    if (!this.parent.isSelected && this.parent.source instanceof Note) {
-      ctx.globalAlpha = 0.3;
+    if (!this.parent.isSelected) {
+      ctx.globalAlpha = transitionStyle.notSelectedAlpha;
     }
     drawCurvedLine(ctx, line, 12 / this.app.controller.scale);
     ctx.globalAlpha = 1;

--- a/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithoutLabel.ts
+++ b/src/renderer/src/lib/drawable/TransitionNode/ArrowsWithoutLabel.ts
@@ -1,5 +1,5 @@
 import { CanvasEditor } from '@renderer/lib/CanvasEditor';
-import { Note, Transition } from '@renderer/lib/drawable';
+import { Transition } from '@renderer/lib/drawable';
 import { transitionStyle } from '@renderer/lib/styles';
 import { Drawable } from '@renderer/lib/types/drawable';
 import {

--- a/src/renderer/src/lib/styles.ts
+++ b/src/renderer/src/lib/styles.ts
@@ -25,9 +25,14 @@ export const stateStyle = {
  * Стиль переходов в редакторе машин состояний
  */
 export const transitionStyle = {
-  width: 2,
+  width: 3,
   bgColor: '#FFF',
   startSize: 5,
   padEnd: 5,
-  endSize: 11,
+  endSize: 19,
+  notSelectedAlpha: 0.7,
 };
+
+// width / startSize 2 / 5
+// width / endSize 2 / 11
+// startSize / endSize 5 / 11

--- a/src/renderer/src/lib/styles.ts
+++ b/src/renderer/src/lib/styles.ts
@@ -32,7 +32,3 @@ export const transitionStyle = {
   endSize: 19,
   notSelectedAlpha: 0.7,
 };
-
-// width / startSize 2 / 5
-// width / endSize 2 / 11
-// startSize / endSize 5 / 11


### PR DESCRIPTION
- Opacity добавлено в transitionStyles
- Теперь opacity применяется для стрелок из начального состояния
- Стрелки стали шире 