### PR TITLE
Undo/redo кнопки + Перенос кнопки вызова документации

### DIFF
--- a/src/renderer/src/components/Documentation/Documentation.tsx
+++ b/src/renderer/src/components/Documentation/Documentation.tsx
@@ -4,8 +4,6 @@ import { Resizable } from 're-resizable';
 import { toast } from 'sonner';
 import { twMerge } from 'tailwind-merge';
 
-import { ReactComponent as Question } from '@renderer/assets/icons/question.svg';
-import { EditorSettings } from '@renderer/components';
 import { useFetch, useSettings } from '@renderer/hooks';
 import { useDoc } from '@renderer/store/useDoc';
 import { File } from '@renderer/types/documentation';

--- a/src/renderer/src/components/Documentation/Documentation.tsx
+++ b/src/renderer/src/components/Documentation/Documentation.tsx
@@ -184,7 +184,7 @@ export const Documentation: React.FC<DocumentationProps> = ({ topOffset = false 
             <Question height={40} width={40} />
           </button>
         ) : (
-          <EditorSettings toggle={onDocumentationToggle} />
+          <EditorSettings />
         )}
         <div className="h-full">{renderContent()}</div>
       </Resizable>

--- a/src/renderer/src/components/Documentation/Documentation.tsx
+++ b/src/renderer/src/components/Documentation/Documentation.tsx
@@ -18,11 +18,7 @@ export interface CurrentItem {
   path: string;
 }
 
-interface DocumentationProps {
-  topOffset?: boolean;
-}
-
-export const Documentation: React.FC<DocumentationProps> = ({ topOffset = false }) => {
+export const Documentation: React.FC = () => {
   const [doc] = useSettings('doc');
   const url = doc?.host ?? '';
 

--- a/src/renderer/src/components/Documentation/Documentation.tsx
+++ b/src/renderer/src/components/Documentation/Documentation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { Resizable } from 're-resizable';
 import { toast } from 'sonner';
@@ -162,32 +162,15 @@ export const Documentation: React.FC<DocumentationProps> = ({ topOffset = false 
   }, [error]);
 
   return (
-    <div
-      className={twMerge(
-        'absolute right-0 top-0 flex h-full',
-        topOffset && 'top-[44.19px] h-[calc(100vh-44.19px)]'
-      )}
+    <Resizable
+      enable={{ left: true }}
+      size={{ width: width, height: '100%' }}
+      minWidth={minWidth}
+      maxWidth={maxWidth}
+      onResize={handleResize}
+      className="border-l border-border-primary bg-bg-secondary"
     >
-      <Resizable
-        enable={{ left: true }}
-        size={{ width: width, height: '100%' }}
-        minWidth={minWidth}
-        maxWidth={maxWidth}
-        onResize={handleResize}
-        className="border-l border-border-primary bg-bg-secondary"
-      >
-        {!topOffset ? (
-          <button
-            className="absolute -left-14 bottom-0 m-2 text-primary"
-            onClick={onDocumentationToggle}
-          >
-            <Question height={40} width={40} />
-          </button>
-        ) : (
-          <EditorSettings />
-        )}
-        <div className="h-full">{renderContent()}</div>
-      </Resizable>
-    </div>
+      <div className="h-full">{renderContent()}</div>
+    </Resizable>
   );
 };

--- a/src/renderer/src/components/EditorSettings.tsx
+++ b/src/renderer/src/components/EditorSettings.tsx
@@ -2,18 +2,13 @@ import React from 'react';
 
 import { ReactComponent as Arrow } from '@renderer/assets/icons/arrow-right.svg';
 import { ReactComponent as Grid } from '@renderer/assets/icons/grid.svg';
-import { ReactComponent as Question } from '@renderer/assets/icons/question.svg';
 import { ReactComponent as ZoomIn } from '@renderer/assets/icons/zoom-in.svg';
 import { ReactComponent as ZoomOut } from '@renderer/assets/icons/zoom-out.svg';
 import { useSettings } from '@renderer/hooks/useSettings';
 import { useModelContext } from '@renderer/store/ModelContext';
 import { useTabs } from '@renderer/store/useTabs';
 
-export interface EditorSettingsProps {
-  toggle: () => void;
-}
-
-export const EditorSettings: React.FC<EditorSettingsProps> = ({ toggle }) => {
+export const EditorSettings: React.FC = () => {
   const [activeTabName, items] = useTabs((state) => [state.activeTab, state.items]);
   const activeTab = items.find((tab) => tab.name === activeTabName);
   const modelController = useModelContext();
@@ -54,7 +49,7 @@ export const EditorSettings: React.FC<EditorSettingsProps> = ({ toggle }) => {
 
   return (
     activeTab?.type === 'editor' && (
-      <div className="absolute -left-[300px] bottom-3 flex items-stretch overflow-hidden rounded bg-bg-secondary">
+      <div className="absolute -left-[280px] bottom-3 flex items-stretch overflow-hidden rounded bg-bg-secondary">
         <button
           className="rotate-180 px-2 outline-none hover:bg-bg-hover active:bg-bg-active"
           onClick={handleUndo}
@@ -95,13 +90,6 @@ export const EditorSettings: React.FC<EditorSettingsProps> = ({ toggle }) => {
           onClick={handleZoomIn}
         >
           <ZoomIn width={20} height={20} />
-        </button>
-
-        <button
-          className="px-2 text-primary outline-none hover:bg-bg-hover active:bg-bg-active"
-          onClick={toggle}
-        >
-          <Question height={20} width={20} />
         </button>
       </div>
     )

--- a/src/renderer/src/components/EditorSettings.tsx
+++ b/src/renderer/src/components/EditorSettings.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { ReactComponent as Arrow } from '@renderer/assets/icons/arrow-right.svg';
 import { ReactComponent as Grid } from '@renderer/assets/icons/grid.svg';
 import { ReactComponent as Question } from '@renderer/assets/icons/question.svg';
 import { ReactComponent as ZoomIn } from '@renderer/assets/icons/zoom-in.svg';
@@ -34,6 +35,14 @@ export const EditorSettings: React.FC<EditorSettingsProps> = ({ toggle }) => {
     controller.view.changeScale(1, true);
   };
 
+  const handleUndo = () => {
+    modelController.history.undo();
+  };
+
+  const handleRedo = () => {
+    modelController.history.redo();
+  };
+
   const handleCanvasGrid = () => {
     setCanvasSettings({
       ...canvasSettings!,
@@ -45,7 +54,21 @@ export const EditorSettings: React.FC<EditorSettingsProps> = ({ toggle }) => {
 
   return (
     activeTab?.type === 'editor' && (
-      <div className="absolute -left-60 bottom-3 flex items-stretch overflow-hidden rounded bg-bg-secondary">
+      <div className="absolute -left-[300px] bottom-3 flex items-stretch overflow-hidden rounded bg-bg-secondary">
+        <button
+          className="rotate-180 px-2 outline-none hover:bg-bg-hover active:bg-bg-active"
+          onClick={handleUndo}
+        >
+          <Arrow width={20} height={20} />
+        </button>
+
+        <button
+          className="px-2 outline-none hover:bg-bg-hover active:bg-bg-active"
+          onClick={handleRedo}
+        >
+          <Arrow width={20} height={20} />
+        </button>
+
         <button
           className="px-2 outline-none hover:bg-bg-hover active:bg-bg-active"
           onClick={handleCanvasGrid}

--- a/src/renderer/src/components/MainContainer/MainContainer.tsx
+++ b/src/renderer/src/components/MainContainer/MainContainer.tsx
@@ -12,6 +12,7 @@ import {
   Sidebar,
   UpdateModal,
   DiagramContextMenu,
+  EditorSettings,
 } from '@renderer/components';
 import { hideLoadingOverlay } from '@renderer/components/utils/OverlayControl';
 import { useErrorModal, useFileOperations } from '@renderer/hooks';
@@ -90,8 +91,15 @@ export const MainContainer: React.FC = () => {
           <input {...getInputProps()} />
 
           <Tabs />
-
-          <Documentation topOffset={!!isMounted} />
+          <div
+            className={twMerge(
+              'absolute right-0 top-0 flex h-full',
+              !!isMounted && 'top-[44.19px] h-[calc(100vh-44.19px)]'
+            )}
+          >
+            <Documentation topOffset={!!isMounted} />
+            <EditorSettings />
+          </div>
         </div>
 
         {isMounted && <DiagramContextMenu />}

--- a/src/renderer/src/components/MainContainer/MainContainer.tsx
+++ b/src/renderer/src/components/MainContainer/MainContainer.tsx
@@ -97,7 +97,7 @@ export const MainContainer: React.FC = () => {
               !!isMounted && 'top-[44.19px] h-[calc(100vh-44.19px)]'
             )}
           >
-            <Documentation topOffset={!!isMounted} />
+            <Documentation />
             <EditorSettings />
           </div>
         </div>

--- a/src/renderer/src/components/Sidebar/Labels.tsx
+++ b/src/renderer/src/components/Sidebar/Labels.tsx
@@ -6,7 +6,7 @@ import { WithHint } from '@renderer/components/UI';
 import { useSidebar } from '@renderer/store/useSidebar';
 
 interface LabelsProps {
-  items: Array<{ Icon: JSX.Element; bottom?: boolean; hint: string }>;
+  items: Array<{ Icon: JSX.Element; bottom?: boolean; hint: string; action?: () => void }>;
 }
 
 export const Labels: React.FC<LabelsProps> = ({ items }) => {
@@ -14,7 +14,7 @@ export const Labels: React.FC<LabelsProps> = ({ items }) => {
 
   return (
     <div className="flex flex-col border-r border-border-primary bg-bg-primary">
-      {items.map(({ Icon, bottom = false, hint }, i) => (
+      {items.map(({ Icon, bottom = false, hint, action }, i) => (
         <WithHint key={i} hint={hint} placement="right" offset={5} delay={100}>
           {(props) => (
             <button
@@ -23,7 +23,7 @@ export const Labels: React.FC<LabelsProps> = ({ items }) => {
                 activeTab === i && 'border-primary text-text-primary',
                 bottom && 'mt-auto'
               )}
-              onClick={() => changeTab(i)}
+              onClick={action ?? (() => changeTab(i))}
               {...props}
             >
               {Icon}

--- a/src/renderer/src/components/Sidebar/Sidebar.tsx
+++ b/src/renderer/src/components/Sidebar/Sidebar.tsx
@@ -5,11 +5,13 @@ import { ReactComponent as ComponentsIcon } from '@renderer/assets/icons/compone
 import { ReactComponent as FlasherIcon } from '@renderer/assets/icons/flasher.svg';
 import { ReactComponent as HistoryIcon } from '@renderer/assets/icons/history.svg';
 import { ReactComponent as MenuIcon } from '@renderer/assets/icons/menu.svg';
+import { ReactComponent as DocumentationIcon } from '@renderer/assets/icons/question.svg';
 import { ReactComponent as SettingsIcon } from '@renderer/assets/icons/settings.svg';
 import { ReactComponent as StateIcon } from '@renderer/assets/icons/state_add.svg';
 import { useSettings } from '@renderer/hooks';
 import { useModal } from '@renderer/hooks/useModal';
 import { useModelContext } from '@renderer/store/ModelContext';
+import { useDoc } from '@renderer/store/useDoc';
 import { CompilerResult } from '@renderer/types/CompilerTypes';
 
 import { CompilerTab } from './Compiler';
@@ -67,6 +69,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
   >(undefined);
   const [compilerData, setCompilerData] = useState<CompilerResult | undefined>(undefined);
   const [compilerStatus, setCompilerStatus] = useState('Не подключен.');
+  const [onDocumentationToggle] = useDoc((state) => [state.onDocumentationToggle]);
 
   const isEditorDataStale = modelController.model.useData('', 'isStale');
 
@@ -115,6 +118,7 @@ export const Sidebar: React.FC<SidebarProps> = ({
         openAvrdudeGuideModal={openAvrdudeGuideModal}
       />,
       <History />,
+      undefined,
       <Setting
         openCompilerSettings={openCompilerSettings}
         openLoaderSettings={openLoaderSettings}
@@ -162,6 +166,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
         Icon: <HistoryIcon />,
         hint: 'История изменений',
         bottom: true,
+      },
+      {
+        Icon: <DocumentationIcon />,
+        hint: 'Документация',
+        action: () => onDocumentationToggle(),
       },
       {
         Icon: <SettingsIcon />,

--- a/src/renderer/src/store/useSidebar.ts
+++ b/src/renderer/src/store/useSidebar.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-
+// (Roundabout) TODO: поменять систему индексов
 export enum SidebarIndex {
   Menu,
   StateMachineList,
@@ -7,7 +7,7 @@ export enum SidebarIndex {
   Compiler,
   Flasher,
   History,
-  Settings,
+  Settings = 7, // 6-ой элемент - это документация, но она не является вкладкой
 }
 
 interface SidebarState {


### PR DESCRIPTION
- Сделано в одном PR, чтобы избежать merge-конфликтов.
- Нужно найти новый значок для документации.
- Нужно подобрать значки для undo/redo.
- В будущем, нужно будет переделать индексацию вкладок на сайдбаре. Пришлось использовать костыли, чтобы документация не поломала индексацию.