### PR TITLE
Увеличение отступа от заголовка темы до селектора

### DIFF
--- a/src/renderer/src/components/Sidebar/Setting.tsx
+++ b/src/renderer/src/components/Sidebar/Setting.tsx
@@ -70,7 +70,7 @@ export const Setting: React.FC<SettingProps> = ({ openCompilerSettings, openLoad
       {/* 44.8 - это высота заголовка сверху, а высота считается для того чтобы кнопка "О программе" была внизу */}
       <div className="flex h-[calc(100%-44.8px)] flex-col gap-2 px-4 pb-4">
         <div className="mb-4">
-          Тема
+          <div className="mb-1">Тема</div>
           <Select
             options={themeOptions}
             value={themeOptions.find((o) => o.value === theme)}


### PR DESCRIPTION
Было:
![image](https://github.com/user-attachments/assets/95d83079-43af-43cb-8461-fd6e72da74e3)
Стало:
![image](https://github.com/user-attachments/assets/780712a8-0707-4a5d-b5a8-2bf2133f20c0)
