### PR TITLE
Ctrl-Shift-R для перезагрузки окна вместо Ctrl-R

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,5 @@
 import { optimizer, is } from '@electron-toolkit/utils';
-import { app, shell, BrowserWindow, ipcMain } from 'electron';
+import { app, shell, BrowserWindow, ipcMain, globalShortcut } from 'electron';
 import settings from 'electron-settings';
 import { lookpath } from 'lookpath';
 
@@ -157,6 +157,12 @@ app.whenReady().then(() => {
   // См. https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
   app.on('browser-window-created', (_, window) => {
     optimizer.watchWindowShortcuts(window);
+  });
+
+  // отключение перезагрузки по CmdOrCtrl + R
+  // перезагрузка по Shift + CmdOrCtrl + R должна работать
+  globalShortcut.register('CommandOrControl+R', () => {
+    console.log('CommandOrControl+R is pressed: Shortcut Disabled');
   });
 
   app.on('activate', function () {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,4 @@
-import { optimizer, is } from '@electron-toolkit/utils';
+import { is } from '@electron-toolkit/utils';
 import { app, shell, BrowserWindow, ipcMain, globalShortcut } from 'electron';
 import settings from 'electron-settings';
 import { lookpath } from 'lookpath';
@@ -149,14 +149,6 @@ app.whenReady().then(() => {
     } else {
       return false;
     }
-  });
-
-  // Горячие клавиши для режима разрабочика:
-  // - F12 – инструменты разработки
-  // - CmdOrCtrl + R – перезагрузить страницу
-  // См. https://github.com/alex8088/electron-toolkit/tree/master/packages/utils
-  app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window);
   });
 
   // отключение перезагрузки по CmdOrCtrl + R


### PR DESCRIPTION
Это PR также удаляется `optimizer` из `@electron-toolkit/utils`, так как он не влияет на горячие клавиши.