### PR TITLE
Загрузчик: исправление бага с потерей ID центральной платы МС-ТЮК

### DIFF
--- a/src/renderer/src/hooks/useFlasherHooks.ts
+++ b/src/renderer/src/hooks/useFlasherHooks.ts
@@ -109,7 +109,7 @@ export const useFlasherHooks = () => {
     }
     if (deviceMS && deviceMS.deviceID === deviceID) {
       if (msDevicesCnt === 2) {
-        for (const [, dev] of devices) {
+        for (const [, dev] of newMap) {
           if (dev.isMSDevice()) {
             setDeviceMS(dev as MSDevice);
             break;


### PR DESCRIPTION
Если подключить две центральный платы (через USB), а затем отключить одну из них, то может возникнуть ситуация, когда IDE терял ID той центральной платы, через которую нужно загружать прошивки.