### PR TITLE
Исправление наименования вкладок с отчётами прошивок для МС-ТЮК

### DIFF
--- a/src/renderer/src/hooks/useFlasherHooks.ts
+++ b/src/renderer/src/hooks/useFlasherHooks.ts
@@ -161,7 +161,12 @@ export const useFlasherHooks = () => {
     } else {
       if (Flasher.currentFlashingDevice.isMSDevice()) {
         const msDev = Flasher.currentFlashingDevice as MSDevice;
-        flashResultKey = `${ManagerMS.getFlashingAddress()?.name} - ${msDev.displayName()}`;
+        const getName = () => {
+          const addressInfo = ManagerMS.getFlashingAddress();
+          if (!addressInfo) return 'Неизвестная плата';
+          return addressInfo.name ? addressInfo.name : addressInfo.address;
+        };
+        flashResultKey = `${getName()} - ${msDev.displayName()}`;
         addressInfo = ManagerMS.getFlashingAddress();
         ManagerMS.flashingAddressEndLog(result);
       } else {


### PR DESCRIPTION
Если у платы не было указано имени в IDE, то названия вкладки с отчётом выглядело следующим образом " - МС-ТЮК (COM4)", теперь же названия будет выглядеть так "668e739880610dc1 - МС-ТЮК (COM4)", где первая часть - это адрес платы.
close #857 