### PR TITLE
Исправление смены активной вкладки

### DIFF
--- a/src/renderer/src/components/MainContainer/Tabs/Tabs.tsx
+++ b/src/renderer/src/components/MainContainer/Tabs/Tabs.tsx
@@ -86,10 +86,7 @@ export const Tabs: React.FC = () => {
             onDragStart={() => handleDrag(tab.name)}
             onDrop={() => handleDrop(tab.name)}
             onMouseDown={() => {
-              if (tab.type === 'editor') {
-                modelController.model.changeHeadControllerId(tab.canvasId);
-              }
-              setActiveTab(tab.name);
+              setActiveTab(modelController, tab.name);
             }}
             onClose={() => {
               closeTab(tab.name, modelController);

--- a/src/renderer/src/hooks/useFileOperations.ts
+++ b/src/renderer/src/hooks/useFileOperations.ts
@@ -66,7 +66,7 @@ export const useFileOperations = (args: useFileOperationsArgs) => {
       if (!firstTabName) firstTabName = tabName;
     }
     if (firstTabName) {
-      setActiveTab(firstTabName);
+      setActiveTab(modelController, firstTabName);
     }
   };
 

--- a/src/renderer/src/lib/data/EditorModel/FilesManager.ts
+++ b/src/renderer/src/lib/data/EditorModel/FilesManager.ts
@@ -29,7 +29,7 @@ export class FilesManager {
       elements.stateMachines[sm.id] = emptyStateMachine();
       elements.stateMachines[sm.id].platform = sm.platform.id;
     }
-    this.modelController.initData(null, 'Без названия', elements as any, true);
+    this.modelController.initData(null, 'Без названия', elements, true);
     return this.modelController.model.data.headControllerId;
     // this.modelController.model.init(null, 'Без названия', elements as any);
   }

--- a/src/renderer/src/store/useTabs.ts
+++ b/src/renderer/src/store/useTabs.ts
@@ -6,7 +6,7 @@ import { Tab } from '@renderer/types/tabs';
 interface TabsState {
   items: Tab[];
   activeTab: string | null;
-  setActiveTab: (tabName: string) => void;
+  setActiveTab: (modelController: ModelController, tabName: string) => void;
   openTab: (modelController: ModelController, tab: Tab) => void;
   closeTab: (tabName: string, modelController: ModelController) => void;
   swapTabs: (a: string, b: string) => void;
@@ -19,8 +19,15 @@ interface TabsState {
 export const useTabs = create<TabsState>((set) => ({
   items: [],
   activeTab: 'editor',
-  setActiveTab: (activeTab) => {
-    set({ activeTab });
+  setActiveTab: (modelController, activeTab) => {
+    set(({ items }) => {
+      const tab = items.find(({ name }) => name === activeTab);
+      if (!tab) return {};
+      if (tab.type === 'editor') {
+        modelController.model.changeHeadControllerId(tab.canvasId);
+      }
+      return { activeTab: activeTab };
+    });
   },
   openTab: (modelController, tab) =>
     set(({ items }) => {


### PR DESCRIPTION
При смене активной вкладки, не учитывалось содержит ли вкладка холст или нет, из-за этого не менялся ID текущего контроллера (headControllerId). 

Это приводило к тому, что при создании документа сразу с несколькими МС, отрывалась вкладка с холстом первой по порядку МС, но при этом список компонетнов и иерархия принадлежали последней МС.