### PR TITLE
Контрастный цвет текста для кнопки продвинутого режима в загрузчике

### DIFF
--- a/src/renderer/src/components/Sidebar/Flasher/Flasher.tsx
+++ b/src/renderer/src/components/Sidebar/Flasher/Flasher.tsx
@@ -910,7 +910,7 @@ export const FlasherTab: React.FC = () => {
         <button
           className={twMerge(
             'btn-primary ml-auto mr-4 p-2 py-1',
-            isProMode ? '' : 'bg-bg-secondary'
+            isProMode ? '' : 'bg-bg-secondary text-border-contrast'
           )}
           style={{ marginLeft: 'auto' }}
           onClick={() => handleSwitchProMode()}


### PR DESCRIPTION
Неактивная кнопка на светлой теме до фикса:
![image](https://github.com/user-attachments/assets/c0ddc95e-fafb-4ba1-9b9e-235f9e87f5c2)
Неактивная кнопка на светлой теме после фикса:
![image](https://github.com/user-attachments/assets/9e8681ad-4073-417c-b649-1376ea887209)
