### PR TITLE
Фикс проверки обязательных параметров

### DIFF
--- a/src/renderer/src/components/ComponentEditModal.tsx
+++ b/src/renderer/src/components/ComponentEditModal.tsx
@@ -83,7 +83,7 @@ export const ComponentEditModal: React.FC<ComponentEditModalProps> = ({
         parameters[protoParamName] === ''
       ) {
         setErrors((p) => {
-          return { ...p, protoParamName: 'Ошибка! Обязательный параметр' };
+          return { ...p, [protoParamName]: 'Ошибка! Обязательный параметр' };
         });
         errors[protoParamName] = 'Ошибка! Обязательный параметр';
       }
@@ -103,7 +103,6 @@ export const ComponentEditModal: React.FC<ComponentEditModalProps> = ({
     onClose();
   };
 
-  // (L140-beep)Как будто у нас нигде нет имени у компонента
   const componentType = proto.name ?? data.type;
   const componentName = proto.singletone ? componentType : `${componentType} [${id}]`;
 

--- a/src/renderer/src/components/ComponentFormFieldLabel.tsx
+++ b/src/renderer/src/components/ComponentFormFieldLabel.tsx
@@ -54,9 +54,9 @@ export const ComponentFormFieldLabel: React.FC<ComponentFormFieldLabelProps> = (
                 {...props}
                 value={props.value ?? ''}
               />
-              <p className="text-sm text-error">{error}</p>
             </div>
           )}
+          <p className="text-sm text-error">{error}</p>
         </div>
       </Component>
     </div>

--- a/src/renderer/src/components/ComponentFormFields.tsx
+++ b/src/renderer/src/components/ComponentFormFields.tsx
@@ -39,13 +39,8 @@ export const ComponentFormFields: React.FC<ComponentFormFieldsProps> = ({
   const handleInputChange = (name: string, value: string) => {
     const type = allParameters[name]?.type;
 
-    if (
-      !['label', 'labelColor'].includes(name) &&
-      type &&
-      typeof type === 'string' &&
-      validators[type]
-    ) {
-      if (!validators[type](value)) {
+    if (!['label', 'labelColor'].includes(name) && type) {
+      if (typeof type === 'string' && validators[type] && !validators[type](value)) {
         setErrors((p) => ({ ...p, [name]: `Неправильный тип (${formatArgType(type)})` }));
       } else {
         setErrors((p) => ({ ...p, [name]: '' }));
@@ -156,7 +151,7 @@ export const ComponentFormFields: React.FC<ComponentFormFieldsProps> = ({
           return (
             <ComponentFormFieldLabel
               key={idx}
-              error={errors[idx]}
+              error={error}
               label={name}
               labelClassName="whitespace-pre"
               hint={param.description}


### PR DESCRIPTION
- Исправлена проблема, что сброс ошибки при изменении значения работал только для текстового поля. 
- Исправлено сохранение ошибки об отсутствии параметра в структуре errors.
- Исправлено отсутствие сообщения об ошибке, если в ComponentFormFieldLabel есть вложенные компоненты.