### PR TITLE
Хот-фиксы для монитора порта

### DIFF
--- a/src/renderer/src/components/Sidebar/Flasher/SerialMonitor.tsx
+++ b/src/renderer/src/components/Sidebar/Flasher/SerialMonitor.tsx
@@ -250,7 +250,7 @@ export const SerialMonitorTab: React.FC<SerialMonitorTabProps> = ({ isTabOpen })
         SerialMonitor.addLog('Неизвестный режим монитора порта!');
         return;
     }
-    SerialMonitor.addLog(`Перевод в режим «${TextModeOptions[monitorSetting.textMode].label}».`);
+    SerialMonitor.addLog(`Перевод в режим «${TextModeOptions[newTextMode].label}».`);
     setMonitorSetting({
       ...monitorSetting,
       textMode: newTextMode,

--- a/src/renderer/src/components/Sidebar/Flasher/SerialMonitor.tsx
+++ b/src/renderer/src/components/Sidebar/Flasher/SerialMonitor.tsx
@@ -239,6 +239,9 @@ export const SerialMonitorTab: React.FC<SerialMonitorTabProps> = ({ isTabOpen })
   };
 
   const settingTextMode = (newTextMode: TextModeType) => {
+    if (newTextMode === monitorSetting.textMode) {
+      return;
+    }
     switch (newTextMode) {
       case 'hex':
         setMessages(SerialMonitor.toHex(bytesFromDevice));


### PR DESCRIPTION
- Исправление бага из-за которого в сообщение о смене режима монитора порта указывалось старое название режима, а не новое (например, "Перевод в режим Текст", вместо "Перевод в режим HEX")
- Если пользователь в селекторе выберет текущий режим, то это действие проигнорируется (например, выбор режима "Текст", когда монитор порта уже находится в этом режиме)