### PR TITLE
Исправление udev-rules скрипта

### DIFF
--- a/build/udev-rules.sh
+++ b/build/udev-rules.sh
@@ -10,7 +10,7 @@ fi
 
 # Добавляем правило в файл
 echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="ac01", GROUP="dialout", MODE="0666"' > "$UDEV_RULES_FILE"
-echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="21bb", ATTRS{idProduct}=="f001", GROUP="dialout", MODE="0666"' > "$UDEV_RULES_FILE"
+echo 'SUBSYSTEM=="usb", ATTRS{idVendor}=="21bb", ATTRS{idProduct}=="f001", GROUP="dialout", MODE="0666"' >> "$UDEV_RULES_FILE"
 
 # Перезагружаем правила udev
 udevadm control --reload-rules


### PR DESCRIPTION
Из-за перезаписи в старом варианте записывалась только одна строка, вместо двух. В новом варианте строка вторая строка просто добавляется вместо перезаписи.