### PR TITLE
Выделение зависимостей за пределы exe-файла

### DIFF
--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -47,6 +47,8 @@ jobs:
             npm run bundle:win
             VERSION=$(node -p "require('./package.json').version")
             mkdir -p outputs
+            rm -rf outputs/seafile-upload
+            mkdir -p outputs/seafile-upload
             rm -rf outputs/windows-release
             mkdir -p outputs/windows-release
             cp dist/*-setup.exe outputs/windows-release/
@@ -65,6 +67,10 @@ jobs:
             cp dist/*.deb outputs/
             cp dist/*.snap outputs/
             cp dist/*.AppImage outputs/
+            cp outputs/cyberiada-${VERSION}-windows.zip outputs/seafile-upload/
+            cp dist/*.deb outputs/seafile-upload/
+            cp dist/*.snap outputs/seafile-upload/
+            cp dist/*.AppImage outputs/seafile-upload/
 
       - name: Get current date
         id: date
@@ -80,11 +86,7 @@ jobs:
           repo-id: ${{ secrets.SEAFILE_REPO_ID }}
           remote-path: '/'
           # remote-path: /${{ env.date }}
-          local-path: |
-            outputs/cyberiada-*-windows.zip
-            outputs/*.deb
-            outputs/*.snap
-            outputs/*.AppImage
+          local-path: 'outputs/seafile-upload/*'
           overwrite: 'true'
 
       - name: Save deb artifact

--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -46,16 +46,17 @@ jobs:
             npm run bundle:linux
             npm run bundle:win
             VERSION=$(node -p "require('./package.json').version")
+
             mkdir -p outputs
-            rm -rf outputs/seafile-upload
             mkdir -p outputs/seafile-upload
-            rm -rf outputs/windows-release
-            mkdir -p outputs/windows-release
-            cp dist/*-setup.exe outputs/windows-release/
             mkdir -p outputs/windows-release/setup_data
+
+            cp dist/*-setup.exe outputs/windows-release/
             cp -r build/gcc-arm-none-eabi outputs/windows-release/setup_data/gcc-arm-none-eabi
+            
             mkdir -p outputs/windows-release/setup_data/irpcb
             cp -r build/irpcb/bin outputs/windows-release/setup_data/irpcb/bin
+            
             mkdir -p outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser
             cp -r build/lapki-compiler/compiler/library outputs/windows-release/setup_data/lapki-compiler/library
             cp -r build/lapki-compiler/compiler/platforms outputs/windows-release/setup_data/lapki-compiler/platforms
@@ -64,9 +65,6 @@ jobs:
               cd outputs/windows-release
               zip -r "../cyberiada-${VERSION}-windows.zip" .
             )
-            cp dist/*.deb outputs/
-            cp dist/*.snap outputs/
-            cp dist/*.AppImage outputs/
             cp outputs/cyberiada-${VERSION}-windows.zip outputs/seafile-upload/
             cp dist/*.deb outputs/seafile-upload/
             cp dist/*.snap outputs/seafile-upload/

--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -33,14 +33,14 @@ jobs:
           wget https://seafile.polyus-nt.ru/f/6377a640bc344e31bd6d/?dl=1 -O build/irpcb.zip
           unzip build/irpcb.zip -d build/irpcb
           rm -f build/irpcb.zip
-      - name: Install zip
-        run: sudo apt-get update && sudo apt-get install -y zip
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
           image: electronuserland/builder:wine
           options: -v ${{ github.workspace }}:/project
           run: |
+            apt-get update
+            apt-get install -y zip
             npm ci
             npm run build
             npm run bundle:linux

--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -26,8 +26,6 @@ jobs:
       - name: Download gcc-arm-none-eabi
         run: |
           wget https://seafile.polyus-nt.ru/f/83d0be836d1c491fa3b3/?dl=1 -O build/gcc-arm-none-eabi.zip
-          unzip build/gcc-arm-none-eabi.zip -d build/gcc-arm-none-eabi
-          rm -f build/gcc-arm-none-eabi.zip
       - name: Download IRPCB dependencies
         run: |
           wget https://seafile.polyus-nt.ru/f/6377a640bc344e31bd6d/?dl=1 -O build/irpcb.zip
@@ -52,7 +50,7 @@ jobs:
             mkdir -p outputs/windows-release/setup_data
 
             cp dist/*-setup.exe outputs/windows-release/
-            cp -r build/gcc-arm-none-eabi outputs/windows-release/setup_data/gcc-arm-none-eabi
+            cp build/gcc-arm-none-eabi.zip outputs/windows-release/setup_data/gcc-arm-none-eabi.zip
             
             mkdir -p outputs/windows-release/setup_data/irpcb
             cp -r build/irpcb/bin outputs/windows-release/setup_data/irpcb/bin

--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -43,9 +43,24 @@ jobs:
             npm run build
             npm run bundle:linux
             npm run bundle:win
+            VERSION=$(node -p "require('./package.json').version")
             mkdir -p outputs
+            rm -rf outputs/windows-release
+            mkdir -p outputs/windows-release
+            cp dist/*-setup.exe outputs/windows-release/
+            mkdir -p outputs/windows-release/setup_data
+            cp -r build/gcc-arm-none-eabi outputs/windows-release/setup_data/gcc-arm-none-eabi
+            mkdir -p outputs/windows-release/setup_data/irpcb
+            cp -r build/irpcb/bin outputs/windows-release/setup_data/irpcb/bin
+            mkdir -p outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser
+            cp -r build/lapki-compiler/compiler/library outputs/windows-release/setup_data/lapki-compiler/library
+            cp -r build/lapki-compiler/compiler/platforms outputs/windows-release/setup_data/lapki-compiler/platforms
+            cp -r build/lapki-compiler/compiler/fullgraphmlparser/templates outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser/templates
+            (
+              cd outputs/windows-release
+              zip -r "../cyberiada-${VERSION}-windows.zip" .
+            )
             cp dist/*.deb outputs/
-            cp dist/*.exe outputs/
             cp dist/*.snap outputs/
             cp dist/*.AppImage outputs/
 
@@ -79,6 +94,13 @@ jobs:
           name: exe-build
           path: |
             dist/*.exe
+
+      - name: Save windows zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-zip-build
+          path: |
+            outputs/cyberiada-*-windows.zip
 
       - name: Save snap artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/manual-release-seafile.yml
+++ b/.github/workflows/manual-release-seafile.yml
@@ -33,6 +33,8 @@ jobs:
           wget https://seafile.polyus-nt.ru/f/6377a640bc344e31bd6d/?dl=1 -O build/irpcb.zip
           unzip build/irpcb.zip -d build/irpcb
           rm -f build/irpcb.zip
+      - name: Install zip
+        run: sudo apt-get update && sudo apt-get install -y zip
       - name: Run the build process with Docker
         uses: addnab/docker-run-action@v3
         with:
@@ -78,7 +80,11 @@ jobs:
           repo-id: ${{ secrets.SEAFILE_REPO_ID }}
           remote-path: '/'
           # remote-path: /${{ env.date }}
-          local-path: 'outputs/*'
+          local-path: |
+            outputs/cyberiada-*-windows.zip
+            outputs/*.deb
+            outputs/*.snap
+            outputs/*.AppImage
           overwrite: 'true'
 
       - name: Save deb artifact

--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Download gcc-arm-none-eabi
         run: |
           wget https://seafile.polyus-nt.ru/f/83d0be836d1c491fa3b3/?dl=1 -O build/gcc-arm-none-eabi.zip
-          unzip build/gcc-arm-none-eabi.zip -d build/gcc-arm-none-eabi
-          rm -f build/gcc-arm-none-eabi.zip
       - name: Download IRPCB dependencies
         run: |
           wget https://seafile.polyus-nt.ru/f/6377a640bc344e31bd6d/?dl=1 -O build/irpcb.zip
@@ -38,11 +36,36 @@ jobs:
           image: electronuserland/builder:wine
           options: -v ${{ github.workspace }}:/project
           run: |
+            apt-get update
+            apt-get install -y zip
             npm ci
             npm run build
             npm run bundle:linux
             npm run bundle:win
+            VERSION=$(node -p "require('./package.json').version")
 
+            mkdir -p outputs
+            mkdir -p outputs/seafile-upload
+            mkdir -p outputs/windows-release/setup_data
+
+            cp dist/*-setup.exe outputs/windows-release/
+            cp build/gcc-arm-none-eabi.zip outputs/windows-release/setup_data/gcc-arm-none-eabi.zip
+            
+            mkdir -p outputs/windows-release/setup_data/irpcb
+            cp -r build/irpcb/bin outputs/windows-release/setup_data/irpcb/bin
+            
+            mkdir -p outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser
+            cp -r build/lapki-compiler/compiler/library outputs/windows-release/setup_data/lapki-compiler/library
+            cp -r build/lapki-compiler/compiler/platforms outputs/windows-release/setup_data/lapki-compiler/platforms
+            cp -r build/lapki-compiler/compiler/fullgraphmlparser/templates outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser/templates
+            (
+              cd outputs/windows-release
+              zip -r "../cyberiada-${VERSION}-windows.zip" .
+            )
+            cp outputs/cyberiada-${VERSION}-windows.zip outputs/seafile-upload/
+            cp dist/*.deb outputs/seafile-upload/
+            cp dist/*.snap outputs/seafile-upload/
+            cp dist/*.AppImage outputs/seafile-upload/
       - name: Save deb artifact
         uses: actions/upload-artifact@v4
         with:
@@ -63,6 +86,13 @@ jobs:
           name: snap-build
           path: |
             dist/*.snap
+
+      - name: Save windows zip artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-zip-build
+          path: |
+            outputs/cyberiada-*-windows.zip
 
       - name: Save AppImage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Download gcc-arm-none-eabi
         run: |
           wget https://seafile.polyus-nt.ru/f/83d0be836d1c491fa3b3/?dl=1 -O build/gcc-arm-none-eabi.zip
-          unzip build/gcc-arm-none-eabi.zip -d build/gcc-arm-none-eabi
-          rm -f build/gcc-arm-none-eabi.zip
       - name: Download IRPCB dependencies
         run: |
           wget https://seafile.polyus-nt.ru/f/6377a640bc344e31bd6d/?dl=1 -O build/irpcb.zip
@@ -46,10 +44,36 @@ jobs:
           image: electronuserland/builder:wine
           options: -v ${{ github.workspace }}:/project
           run: |
+            apt-get update
+            apt-get install -y zip
             npm ci
             npm run build
             npm run bundle:linux
             npm run bundle:win
+            VERSION=$(node -p "require('./package.json').version")
+
+            mkdir -p outputs
+            mkdir -p outputs/seafile-upload
+            mkdir -p outputs/windows-release/setup_data
+
+            cp dist/*-setup.exe outputs/windows-release/
+            cp build/gcc-arm-none-eabi.zip outputs/windows-release/setup_data/gcc-arm-none-eabi.zip
+            
+            mkdir -p outputs/windows-release/setup_data/irpcb
+            cp -r build/irpcb/bin outputs/windows-release/setup_data/irpcb/bin
+            
+            mkdir -p outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser
+            cp -r build/lapki-compiler/compiler/library outputs/windows-release/setup_data/lapki-compiler/library
+            cp -r build/lapki-compiler/compiler/platforms outputs/windows-release/setup_data/lapki-compiler/platforms
+            cp -r build/lapki-compiler/compiler/fullgraphmlparser/templates outputs/windows-release/setup_data/lapki-compiler/fullgraphmlparser/templates
+            (
+              cd outputs/windows-release
+              zip -r "../cyberiada-${VERSION}-windows.zip" .
+            )
+            cp outputs/cyberiada-${VERSION}-windows.zip outputs/seafile-upload/
+            cp dist/*.deb outputs/seafile-upload/
+            cp dist/*.snap outputs/seafile-upload/
+            cp dist/*.AppImage outputs/seafile-upload/
 
       - uses: 'marvinpinto/action-automatic-releases@latest'
         id: 'automatic_releases'
@@ -62,6 +86,7 @@ jobs:
             dist/*.snap
             dist/*.AppImage
             dist/*.exe
+            outputs/*.zip
 
   mac-build:
     runs-on: 'macos-latest'

--- a/build-installer/installer.nsh
+++ b/build-installer/installer.nsh
@@ -1,6 +1,6 @@
 !macro customInit
-  IfFileExists "$EXEDIR\setup_data\gcc-arm-none-eabi\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\gcc-arm-none-eabi. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+  IfFileExists "$EXEDIR\setup_data\gcc-arm-none-eabi.zip" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\gcc-arm-none-eabi.zip. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 
   IfFileExists "$EXEDIR\setup_data\irpcb\bin\*.*" +3 0

--- a/build-installer/installer.nsh
+++ b/build-installer/installer.nsh
@@ -1,72 +1,36 @@
-Section "DriversSection" SEC02
-    SetOutPath "$PLUGINSDIR"
-    ;File /oname=$PLUGINSDIR\wdi-simple64.exe "${BUILD_RESOURCES_DIR}\wdi-simple64.exe"
-    File /oname=$PLUGINSDIR\install.bat "${BUILD_RESOURCES_DIR}\install.bat"
-    File /oname=$PLUGINSDIR\install_compiler_deps.ps1 "${BUILD_RESOURCES_DIR}\install_compiler_deps.ps1"
-    ;File /oname=$PLUGINSDIR\move_compiler_resourses.bat "${BUILD_RESOURCES_DIR}\move_compiler_resourses.bat"
-    ;File /oname=$PLUGINSDIR\move_arm_gcc.bat "${BUILD_RESOURCES_DIR}\move_arm_gcc.bat"
+!macro customInit
+  IfFileExists "$EXEDIR\setup_data\gcc-arm-none-eabi\*.*" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\gcc-arm-none-eabi.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    Abort
 
-    ; создаём у себя поддиректорию
-    CreateDirectory "$PLUGINSDIR\gcc-arm-none-eabi"
+  IfFileExists "$EXEDIR\setup_data\irpcb\bin\*.*" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\irpcb\bin.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    Abort
 
-    ; переключаемся в неё
-    SetOutPath "$PLUGINSDIR\gcc-arm-none-eabi"
+  IfFileExists "$EXEDIR\setup_data\lapki-compiler\library\*.*" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\library.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    Abort
 
-    ; рекурсивно забираем всё из исходной папки
-    File /r "${BUILD_RESOURCES_DIR}\gcc-arm-none-eabi\*.*"
+  IfFileExists "$EXEDIR\setup_data\lapki-compiler\platforms\*.*" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\platforms.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    Abort
 
-    CreateDirectory "$PLUGINSDIR\irpcb\bin"
-    SetOutPath "$PLUGINSDIR\irpcb\bin"
-    File "${BUILD_RESOURCES_DIR}\irpcb\bin\*.*"
-
-    CreateDirectory "$PLUGINSDIR\lapki-compiler"
-    CreateDirectory "$PLUGINSDIR\lapki-compiler\library"
-    CreateDirectory "$PLUGINSDIR\lapki-compiler\platforms"
-    CreateDirectory "$PLUGINSDIR\lapki-compiler\fullgraphmlparser"
-    CreateDirectory "$PLUGINSDIR\lapki-compiler\fullgraphmlparser\templates"
-    ; переключаемся в неё
-    SetOutPath "$PLUGINSDIR\lapki-compiler\library"
-
-    ; TODO: Попробовать засунуть все это в pre-init вызовом скрипта
-    ; рекурсивно забираем всё из исходной папки
-    File /r "${BUILD_RESOURCES_DIR}\lapki-compiler\compiler\library\*.*"
-    SetOutPath "$PLUGINSDIR\lapki-compiler\platforms"
-    File /r "${BUILD_RESOURCES_DIR}\lapki-compiler\compiler\platforms\"
-    SetOutPath "$PLUGINSDIR\lapki-compiler\fullgraphmlparser\templates"
-    File /r "${BUILD_RESOURCES_DIR}\lapki-compiler\compiler\fullgraphmlparser\templates"
-
-    SetOutPath "$PLUGINSDIR"
-    ;ExecWait 'powershell.exe -Command "$PLUGINSDIR\install.bat $PLUGINSDIR"'
-    ExecWait 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\install_compiler_deps.ps1" "$INSTDIR"'
-    ;ExecWait 'powershell.exe -Command "$PLUGINSDIR\move_compiler_resourses.bat ${BUILD_RESOURCES_DIR}"'
-SectionEnd
+  IfFileExists "$EXEDIR\setup_data\lapki-compiler\fullgraphmlparser\templates\*.*" +3 0
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\fullgraphmlparser\templates.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    Abort
+!macroend
 
 !macro customInstall
-  DetailPrint "Running post–install batch…"
+  SetOutPath "$PLUGINSDIR"
+  File /oname=$PLUGINSDIR\install_payload.ps1 "${BUILD_RESOURCES_DIR}\install_payload.ps1"
+  File /oname=$PLUGINSDIR\install_compiler_deps.ps1 "${BUILD_RESOURCES_DIR}\install_compiler_deps.ps1"
 
-  DetailPrint "Copying gcc-arm-none-eabi from $PLUGINSDIR to $INSTDIR…"
-  ; Убедимся, что папка приёмник существует
-  CreateDirectory "$INSTDIR\gcc-arm-none-eabi"
+  DetailPrint "Running external setup data installer..."
+  ExecWait 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\install_payload.ps1" -InstallDir "$INSTDIR" -SetupDataDir "$EXEDIR\setup_data"' $0
+  StrCmp $0 0 payload_done
 
-  ; Рекурсивно скопируем все файлы и подпапки
-  CopyFiles /SILENT "$PLUGINSDIR\gcc-arm-none-eabi\*.*" "$INSTDIR\gcc-arm-none-eabi\"
-  ; Удалим временную директорию (чтобы не оставлять мусор)
-  RMDir /r "$PLUGINSDIR\gcc-arm-none-eabi"
+  MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+  Abort
 
-  DetailPrint "Done. INSTDIR now contains:"
-  DetailPrint "  $INSTDIR\gcc-arm-none-eabi"
-
-  CreateDirectory "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler"
-  CreateDirectory "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\library"
-  CreateDirectory "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\platforms"
-  CreateDirectory "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\fullgraphmlparser"
-  CreateDirectory "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\fullgraphmlparser\templates"
-
-  CreateDirectory "$INSTDIR\irpcb\bin"
-  CopyFiles /SILENT "$PLUGINSDIR\irpcb\bin\*.*" "$INSTDIR\irpcb\bin"
-
-  CopyFiles /SILENT "$PLUGINSDIR\lapki-compiler\library\*.*" "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\library\"
-  CopyFiles /SILENT "$PLUGINSDIR\lapki-compiler\platforms\*.*" "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\platforms\"
-  CopyFiles /SILENT "$PLUGINSDIR\lapki-compiler\fullgraphmlparser\templates\*.*" "$INSTDIR\resources\app.asar.unpacked\resources\modules\win32\lapki-compiler\fullgraphmlparser\"
-  ExecWait "arduino-cli core install arduino:avr"
+  payload_done:
 !macroend

--- a/build-installer/installer.nsh
+++ b/build-installer/installer.nsh
@@ -1,22 +1,22 @@
 !macro customInit
   IfFileExists "$EXEDIR\setup_data\gcc-arm-none-eabi\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\gcc-arm-none-eabi.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\gcc-arm-none-eabi. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 
   IfFileExists "$EXEDIR\setup_data\irpcb\bin\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\irpcb\bin.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\irpcb\bin. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 
   IfFileExists "$EXEDIR\setup_data\lapki-compiler\library\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\library.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\library. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 
   IfFileExists "$EXEDIR\setup_data\lapki-compiler\platforms\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\platforms.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\platforms. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 
   IfFileExists "$EXEDIR\setup_data\lapki-compiler\fullgraphmlparser\templates\*.*" +3 0
-    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\fullgraphmlparser\templates.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+    MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data\lapki-compiler\fullgraphmlparser\templates. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
     Abort
 !macroend
 
@@ -29,7 +29,7 @@
   ExecWait 'powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$PLUGINSDIR\install_payload.ps1" -InstallDir "$INSTDIR" -SetupDataDir "$EXEDIR\setup_data"' $0
   StrCmp $0 0 payload_done
 
-  MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data.`r`n`r`nЭто часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
+  MessageBox MB_ICONSTOP|MB_OK "Не могу найти setup_data. Это часть установочного комплекта. Убедитесь, что вы скачали комплект полностью и разархивировали перед запуском."
   Abort
 
   payload_done:

--- a/build/install_payload.ps1
+++ b/build/install_payload.ps1
@@ -1,111 +1,226 @@
+# Этот скрипт переносит зависимости, внешние данные
+# из папки установки рядом с exe (setup_dir)
+# и устанавливает их в PATH через внешний скрипт
+
 param(
+    # Путь к директории установленного приложения
     [Parameter(Mandatory = $true)]
     [string]$InstallDir,
+
+    # Путь к директории setup_data,
+    # содержащей необходимые payload-файлы и зависимости
     [Parameter(Mandatory = $true)]
     [string]$SetupDataDir
 )
 
+# Включает строгий режим:
+# запрещает использование необъявленных переменных и другие потенциально опасные конструкции
 Set-StrictMode -Version Latest
+
+# Любая ошибка завершает выполнение скрипта
 $ErrorActionPreference = "Stop"
 
+# Проверка существования файла или директории
 function Assert-PathExists {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
+
+        # Тип объекта:
+        # Leaf      -> файл
+        # Container -> папка
         [Parameter(Mandatory = $true)]
         [ValidateSet("Leaf", "Container")]
         [string]$Type
     )
 
+    # Проверяем существование пути
     $exists = Test-Path -LiteralPath $Path -PathType $Type
+
+    # Если объект не найден — выбрасываем ошибку
     if (-not $exists) {
         throw "Required $Type not found: $Path"
     }
 }
 
+# Создание директории, если она отсутствует
 function Ensure-Directory {
     param([Parameter(Mandatory = $true)][string]$Path)
 
+    # Проверяем наличие папки
     if (-not (Test-Path -LiteralPath $Path)) {
+
+        # Создаём папку
         New-Item -ItemType Directory -Path $Path | Out-Null
     }
 }
 
+# Копирование содержимого директории со всеми вложенными файлами
 function Copy-PayloadTree {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Source,
+
         [Parameter(Mandatory = $true)]
         [string]$Destination
     )
 
+    # Проверяем существование исходной папки
     Assert-PathExists -Path $Source -Type Container
+
+    # Гарантируем наличие папки назначения
     Ensure-Directory -Path $Destination
-    Get-ChildItem -LiteralPath $Source -Force | Copy-Item -Destination $Destination -Recurse -Force
+
+    # Копируем всё содержимое рекурсивно
+    Get-ChildItem -LiteralPath $Source -Force |
+        Copy-Item -Destination $Destination -Recurse -Force
 }
 
+function Expand-ArchivePayload {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    Assert-PathExists -Path $ArchivePath -Type Leaf
+
+    # Удаляем старую временную папку если существует
+    if (Test-Path -LiteralPath $Destination) {
+        Remove-Item -LiteralPath $Destination -Recurse -Force
+    }
+
+    # Создаём папку распаковки
+    New-Item -ItemType Directory -Path $Destination | Out-Null
+
+    # Распаковываем архив
+    Expand-Archive `
+        -LiteralPath $ArchivePath `
+        -DestinationPath $Destination `
+        -Force
+}
+
+# Список обязательных директорий,
+# которые должны присутствовать внутри setup_data
 $requiredItems = @(
-    @{ Path = "gcc-arm-none-eabi"; Type = "Container" }
+    @{ Path = "gcc-arm-none-eabi.zip"; Type = "Leaf" }
     @{ Path = "irpcb\bin"; Type = "Container" }
     @{ Path = "lapki-compiler\library"; Type = "Container" }
     @{ Path = "lapki-compiler\platforms"; Type = "Container" }
     @{ Path = "lapki-compiler\fullgraphmlparser\templates"; Type = "Container" }
 )
 
+
+
+# Массив для хранения отсутствующих путей
 $missing = @()
+
+# Проверяем наличие всех обязательных директорий
 foreach ($item in $requiredItems) {
+
+    # Формируем полный путь
     $fullPath = Join-Path $SetupDataDir $item.Path
+
+    # Если путь отсутствует — добавляем в список missing
     if (-not (Test-Path -LiteralPath $fullPath -PathType $item.Type)) {
         $missing += $fullPath
     }
 }
 
+# Если чего-то не хватает — выводим ошибку и завершаем работу
 if ($missing.Count -gt 0) {
     $message = "Missing setup_data items:`n - " + ($missing -join "`n - ")
     Write-Error $message
     exit 2
 }
 
+# Будем разархивировать gcc в TEMP директории, копировать в INSTDIR, 
+# и затем очищать TEMP директорию
+$tempDir = Join-Path $env:TEMP "lapki_setup_tmp"
+$gccTempDir = Join-Path $tempDir "gcc-arm-none-eabi"
+# путь до gcc
+$gccArchive = Join-Path $SetupDataDir "gcc-arm-none-eabi.zip"
+
+Expand-ArchivePayload $gccArchive $gccTempDir
+
+# Корневая папка compiler-модуля внутри установленного приложения
 $compilerRoot = Join-Path $InstallDir "resources\app.asar.unpacked\resources\modules\win32\lapki-compiler"
+
+# План копирования:
+# откуда -> куда
 $copyPlan = @(
+    # ARM GCC toolchain
     @{
-        Source = (Join-Path $SetupDataDir "gcc-arm-none-eabi")
+        Source = $gccTempDir
         Destination = (Join-Path $InstallDir "gcc-arm-none-eabi")
     }
+    # irpcb binaries
     @{
         Source = (Join-Path $SetupDataDir "irpcb\bin")
         Destination = (Join-Path $InstallDir "irpcb\bin")
     }
+    # Библиотеки компилятора
     @{
         Source = (Join-Path $SetupDataDir "lapki-compiler\library")
         Destination = (Join-Path $compilerRoot "library")
     }
+    # Платформы компилятора
     @{
         Source = (Join-Path $SetupDataDir "lapki-compiler\platforms")
         Destination = (Join-Path $compilerRoot "platforms")
     }
+    # Шаблоны fullgraphmlparser
     @{
         Source = (Join-Path $SetupDataDir "lapki-compiler\fullgraphmlparser\templates")
         Destination = (Join-Path $compilerRoot "fullgraphmlparser\templates")
     }
 )
 
+# Выполняем копирование всех payload-данных
 foreach ($step in $copyPlan) {
-    Copy-PayloadTree -Source $step.Source -Destination $step.Destination
+    Copy-PayloadTree `
+        -Source $step.Source `
+        -Destination $step.Destination
 }
 
-$installCompilerDepsScript = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "install_compiler_deps.ps1"
+# Очистка временной распаковки (пока только gcc)
+if (Test-Path -LiteralPath $tempDir) {
+    Remove-Item -LiteralPath $tempDir -Recurse -Force
+}
+
+# Путь к вспомогательному скрипту установки зависимостей в PATH
+$installCompilerDepsScript =
+    Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "install_compiler_deps.ps1"
+
+# Проверяем существование скрипта
 Assert-PathExists -Path $installCompilerDepsScript -Type Leaf
 
-& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installCompilerDepsScript $InstallDir
+# Запускаем install_compiler_deps.ps1
+& powershell.exe `
+    -NoProfile `
+    -ExecutionPolicy Bypass `
+    -File $installCompilerDepsScript `
+    $InstallDir
+
+# Проверяем код завершения
 if ($LASTEXITCODE -ne 0) {
     throw "install_compiler_deps.ps1 failed with exit code $LASTEXITCODE"
 }
 
-$arduinoCliPath = Join-Path $InstallDir "resources\app.asar.unpacked\resources\modules\win32\arduino-cli\arduino-cli.exe"
+# Путь к arduino-cli
+$arduinoCliPath =
+    Join-Path $InstallDir "resources\app.asar.unpacked\resources\modules\win32\arduino-cli\arduino-cli.exe"
+
+# Проверяем наличие arduino-cli.exe
 Assert-PathExists -Path $arduinoCliPath -Type Leaf
 
+# Устанавливаем Arduino AVR core
+# (например, поддержку Arduino Uno/Nano/Mega)
 & $arduinoCliPath core install arduino:avr
+
+# Проверяем успешность установки
 if ($LASTEXITCODE -ne 0) {
     throw "arduino-cli core install arduino:avr failed with exit code $LASTEXITCODE"
 }

--- a/build/install_payload.ps1
+++ b/build/install_payload.ps1
@@ -1,0 +1,111 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$InstallDir,
+    [Parameter(Mandatory = $true)]
+    [string]$SetupDataDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+function Assert-PathExists {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+        [Parameter(Mandatory = $true)]
+        [ValidateSet("Leaf", "Container")]
+        [string]$Type
+    )
+
+    $exists = Test-Path -LiteralPath $Path -PathType $Type
+    if (-not $exists) {
+        throw "Required $Type not found: $Path"
+    }
+}
+
+function Ensure-Directory {
+    param([Parameter(Mandatory = $true)][string]$Path)
+
+    if (-not (Test-Path -LiteralPath $Path)) {
+        New-Item -ItemType Directory -Path $Path | Out-Null
+    }
+}
+
+function Copy-PayloadTree {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Source,
+        [Parameter(Mandatory = $true)]
+        [string]$Destination
+    )
+
+    Assert-PathExists -Path $Source -Type Container
+    Ensure-Directory -Path $Destination
+    Get-ChildItem -LiteralPath $Source -Force | Copy-Item -Destination $Destination -Recurse -Force
+}
+
+$requiredItems = @(
+    @{ Path = "gcc-arm-none-eabi"; Type = "Container" }
+    @{ Path = "irpcb\bin"; Type = "Container" }
+    @{ Path = "lapki-compiler\library"; Type = "Container" }
+    @{ Path = "lapki-compiler\platforms"; Type = "Container" }
+    @{ Path = "lapki-compiler\fullgraphmlparser\templates"; Type = "Container" }
+)
+
+$missing = @()
+foreach ($item in $requiredItems) {
+    $fullPath = Join-Path $SetupDataDir $item.Path
+    if (-not (Test-Path -LiteralPath $fullPath -PathType $item.Type)) {
+        $missing += $fullPath
+    }
+}
+
+if ($missing.Count -gt 0) {
+    $message = "Missing setup_data items:`n - " + ($missing -join "`n - ")
+    Write-Error $message
+    exit 2
+}
+
+$compilerRoot = Join-Path $InstallDir "resources\app.asar.unpacked\resources\modules\win32\lapki-compiler"
+$copyPlan = @(
+    @{
+        Source = (Join-Path $SetupDataDir "gcc-arm-none-eabi")
+        Destination = (Join-Path $InstallDir "gcc-arm-none-eabi")
+    }
+    @{
+        Source = (Join-Path $SetupDataDir "irpcb\bin")
+        Destination = (Join-Path $InstallDir "irpcb\bin")
+    }
+    @{
+        Source = (Join-Path $SetupDataDir "lapki-compiler\library")
+        Destination = (Join-Path $compilerRoot "library")
+    }
+    @{
+        Source = (Join-Path $SetupDataDir "lapki-compiler\platforms")
+        Destination = (Join-Path $compilerRoot "platforms")
+    }
+    @{
+        Source = (Join-Path $SetupDataDir "lapki-compiler\fullgraphmlparser\templates")
+        Destination = (Join-Path $compilerRoot "fullgraphmlparser\templates")
+    }
+)
+
+foreach ($step in $copyPlan) {
+    Copy-PayloadTree -Source $step.Source -Destination $step.Destination
+}
+
+$installCompilerDepsScript = Join-Path (Split-Path -Parent $MyInvocation.MyCommand.Path) "install_compiler_deps.ps1"
+Assert-PathExists -Path $installCompilerDepsScript -Type Leaf
+
+& powershell.exe -NoProfile -ExecutionPolicy Bypass -File $installCompilerDepsScript $InstallDir
+if ($LASTEXITCODE -ne 0) {
+    throw "install_compiler_deps.ps1 failed with exit code $LASTEXITCODE"
+}
+
+$arduinoCliPath = Join-Path $InstallDir "resources\app.asar.unpacked\resources\modules\win32\arduino-cli\arduino-cli.exe"
+Assert-PathExists -Path $arduinoCliPath -Type Leaf
+
+& $arduinoCliPath core install arduino:avr
+if ($LASTEXITCODE -ne 0) {
+    throw "arduino-cli core install arduino:avr failed with exit code $LASTEXITCODE"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,6 +173,7 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -608,6 +609,7 @@
       "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.0.tgz",
       "integrity": "sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==",
+      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -996,6 +998,246 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
+      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
@@ -1006,6 +1248,102 @@
       "optional": true,
       "os": [
         "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -1457,7 +1795,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2412,6 +2749,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
       "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2440,6 +2778,7 @@
       "version": "18.2.51",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.51.tgz",
       "integrity": "sha512-XeoMaU4CzyjdRr3c4IQQtiH7Rpo18V07rYZUucEZQwOUEtGgTXv7e6igQiQ+xnV6MbMe1qjEmKdgMNnfppnXfg==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2451,6 +2790,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2577,6 +2917,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -2936,6 +3277,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "devOptional": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2978,6 +3320,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3514,6 +3857,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001580",
         "electron-to-chromium": "^1.4.648",
@@ -4690,6 +5034,7 @@
       "resolved": "https://registry.npmjs.org/electron/-/electron-24.8.8.tgz",
       "integrity": "sha512-0A2tGwG/0hxnD32Lil9wgSydQ0HCP5AdkgcH+qee3QgaC2jVq55YIbrj/0ZAq4L7yiZvQTzYIrc6kie7OahJKQ==",
       "hasInstallScript": true,
+      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^18.11.18",
@@ -5199,6 +5544,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5337,6 +5683,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -7742,6 +8089,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
       "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "cssstyle": "^3.0.0",
@@ -8856,6 +9204,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -9014,6 +9363,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -9524,6 +9874,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9552,6 +9903,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -9913,6 +10265,7 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -10814,6 +11167,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -10907,7 +11261,6 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
       "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -10925,8 +11278,7 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -11331,6 +11683,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11548,6 +11901,7 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
       "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -12028,6 +12382,7 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
       "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,7 +173,6 @@
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
       "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
@@ -609,7 +608,6 @@
       "version": "6.24.0",
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.24.0.tgz",
       "integrity": "sha512-zK6m5pNkdhdJl8idPP1gA4N8JKTiSsOz8U/Iw+C1ChMwyLG7+MLiNXnH/wFuAk6KeGEe33/adOiAh5jMqee03w==",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.4.0",
         "style-mod": "^4.1.0",
@@ -998,246 +996,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
       "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
-      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
-      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
-      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
-      "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
-      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
-      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
-      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
-      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
-      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
-      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
-      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
-      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
-      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
-      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
-      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@esbuild/linux-x64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
@@ -1248,102 +1006,6 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
-      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
-      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
-      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
-      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.18.20",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
-      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -1795,6 +1457,7 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
       "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.0",
         "@jridgewell/trace-mapping": "^0.3.9"
@@ -2749,7 +2412,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.86.tgz",
       "integrity": "sha512-fifKayi175wLyKyc5qUfyENhQ1dCNI1UNjp653d8kuYcPQN5JhX3dGuP/XmvPTg/xRBn1VTLpbmi+H/Mr7tLfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -2778,7 +2440,6 @@
       "version": "18.2.51",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.51.tgz",
       "integrity": "sha512-XeoMaU4CzyjdRr3c4IQQtiH7Rpo18V07rYZUucEZQwOUEtGgTXv7e6igQiQ+xnV6MbMe1qjEmKdgMNnfppnXfg==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -2790,7 +2451,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.18.tgz",
       "integrity": "sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -2917,7 +2577,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -3277,7 +2936,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
       "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
       "devOptional": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3320,7 +2978,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "devOptional": true,
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3857,7 +3514,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001580",
         "electron-to-chromium": "^1.4.648",
@@ -5034,7 +4690,6 @@
       "resolved": "https://registry.npmjs.org/electron/-/electron-24.8.8.tgz",
       "integrity": "sha512-0A2tGwG/0hxnD32Lil9wgSydQ0HCP5AdkgcH+qee3QgaC2jVq55YIbrj/0ZAq4L7yiZvQTzYIrc6kie7OahJKQ==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@electron/get": "^2.0.0",
         "@types/node": "^18.11.18",
@@ -5544,7 +5199,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
       "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5683,7 +5337,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
       "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.7",
         "array.prototype.findlastindex": "^1.2.3",
@@ -8089,7 +7742,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-22.1.0.tgz",
       "integrity": "sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "abab": "^2.0.6",
         "cssstyle": "^3.0.0",
@@ -9204,7 +8856,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
@@ -9363,7 +9014,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -9874,7 +9524,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9903,7 +9552,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -10265,7 +9913,6 @@
       "version": "3.29.4",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
       "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11167,7 +10814,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
       "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11261,6 +10907,7 @@
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.27.0.tgz",
       "integrity": "sha512-bi1HRwVRskAjheeYl291n3JC4GgO/Ty4z1nVs5AAsmonJulGxpSektecnNedrwK9C7vpvVtcX3cw00VSLt7U2A==",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -11278,7 +10925,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/text-table": {
       "version": "0.2.0",
@@ -11683,7 +11331,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11901,7 +11548,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
       "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",
@@ -12382,7 +12028,6 @@
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
       "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },


### PR DESCRIPTION
Вытащил зависимости из exe-файла, так как появилась проблема с нестабильностью сборки при добавлении новых файлов. 

Теперь у нас собирается exe, внутрь которого кладутся два скрипта-оркестратора. Внешние зависимости кладутся рядом с exe в workflow. При установке NSIS и оркестратор проверяют наличие необходимых файлов и кладут их в директорию установки